### PR TITLE
feat: add dark mode with system preference and manual toggle

### DIFF
--- a/app/components/ThemeToggle.jsx
+++ b/app/components/ThemeToggle.jsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "./ThemeToggle.module.css";
+
+const STORAGE_KEY = "theme";
+
+function getSystemTheme() {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    const resolved = stored ?? getSystemTheme();
+    setTheme(resolved);
+    applyTheme(resolved);
+  }, []);
+
+  function toggle() {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    applyTheme(next);
+    localStorage.setItem(STORAGE_KEY, next);
+  }
+
+  if (theme === null) return null;
+
+  return (
+    <button
+      onClick={toggle}
+      className={styles.toggle}
+      aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+      title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {theme === "dark" ? "☀️" : "🌙"}
+    </button>
+  );
+}

--- a/app/components/ThemeToggle.module.css
+++ b/app/components/ThemeToggle.module.css
@@ -1,0 +1,20 @@
+.toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+  color: var(--text);
+  transition: border-color 0.15s ease;
+}
+
+.toggle:hover,
+.toggle:focus {
+  border-color: var(--link);
+  outline: none;
+}

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,5 +1,6 @@
 import "../styles/globals.css";
 import { Analytics } from "@vercel/analytics/react";
+import ThemeToggle from "./components/ThemeToggle";
 
 export const metadata = {
   title: "Orienteringsordliste",
@@ -12,9 +13,10 @@ export default function RootLayout({
   children,
 }) {
   return (
-    <html lang="no">
+    <html lang="no" suppressHydrationWarning>
       <body>
         <Analytics />
+        <ThemeToggle />
         {children}
       </body>
     </html>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -29,7 +29,7 @@
 .footer {
   width: 100%;
   height: 100px;
-  border-top: 1px solid #eaeaea;
+  border-top: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -42,7 +42,7 @@
 
 .footer a,
 .title a {
-  color: #0070f3;
+  color: var(--link);
   text-decoration: none;
 }
 
@@ -72,7 +72,7 @@
 }
 
 .code {
-  background: #fafafa;
+  background: var(--code-bg);
   border-radius: 5px;
   padding: 0.75rem;
   font-size: 1.1rem;
@@ -96,7 +96,7 @@
   text-align: left;
   color: inherit;
   text-decoration: none;
-  border: 1px solid #eaeaea;
+  border: 1px solid var(--border);
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
 }
@@ -104,8 +104,8 @@
 .card:hover,
 .card:focus,
 .card:active {
-  color: #0070f3;
-  border-color: #0070f3;
+  color: var(--link);
+  border-color: var(--link);
 }
 
 .card h3 {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,9 +1,45 @@
+:root {
+  --bg: #ffffff;
+  --text: #000000;
+  --border: #eaeaea;
+  --link: #0070f3;
+  --code-bg: #fafafa;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #121212;
+    --text: #e5e5e5;
+    --border: #333333;
+    --link: #4da6ff;
+    --code-bg: #1e1e1e;
+  }
+}
+
+[data-theme="light"] {
+  --bg: #ffffff;
+  --text: #000000;
+  --border: #eaeaea;
+  --link: #0070f3;
+  --code-bg: #fafafa;
+}
+
+[data-theme="dark"] {
+  --bg: #121212;
+  --text: #e5e5e5;
+  --border: #333333;
+  --link: #4da6ff;
+  --code-bg: #1e1e1e;
+}
+
 html,
 body {
   padding: 0;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
 }
 
 a {


### PR DESCRIPTION
Closes #88

Implements dark mode using CSS custom properties:

- Automatically follows the system `prefers-color-scheme` setting
- Fixed toggle button (☀️/🌙) in the top-right corner to override the system preference
- User choice is stored in `localStorage` and restored on next visit
- No extra dependencies added