### PR TITLE
feat(dictionary): add missing words from issue #37

### DIFF
--- a/resources/orienteering_dictionary.json
+++ b/resources/orienteering_dictionary.json
@@ -320,5 +320,40 @@
     "tags": [],
     "related": [],
     "aliases": []
+  },
+  {
+    "name": "postplukk",
+    "description": "Etter et orienteringsløp må postene hentes inn fra terrenget. Dette kalles postplukk. Vanligvis er det arrangørklubben som organiserer dette, og det er gjerne løpere som hjelper til.",
+    "tags": [],
+    "related": ["orienteringspost"],
+    "aliases": []
+  },
+  {
+    "name": "ringen",
+    "description": "Ringen er sirkelen som markerer postens nøyaktige posisjon på orienteringskartet. Sirkelen er tegnet rundt det eksakte punktet som skal oppsøkes. <i>Se også <a href=\"/#postbeskrivelse\">postbeskrivelse</a></i>.",
+    "tags": [],
+    "related": ["kart", "orienteringspost", "postbeskrivelse"],
+    "aliases": []
+  },
+  {
+    "name": "startpost",
+    "description": "Startposten er den første posten i et løyp, plassert et stykke fra startstedet. Løperen navigerer selv fra start til startposten. I konkurranser er startposten ofte markert med en trekant på kartet.",
+    "tags": [],
+    "related": ["orienteringspost"],
+    "aliases": []
+  },
+  {
+    "name": "klippetang",
+    "description": "En klippetang er et manuelt stemplingsverktøy som lager et unikt mønster av hull i stempelkortet når det klemmes fast. Klippetangen er et alternativ til elektronisk tidtaking og brukes fortsatt på noen løp. Hvert post har sin egen tang med unikt mønster.",
+    "tags": ["tidtaking"],
+    "related": ["tidtaking", "orienteringspost"],
+    "aliases": []
+  },
+  {
+    "name": "Sportiduino",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> er et åpen kildekode-system for elektronisk tidtaking i orientering, og er et rimeligere alternativ til <a href=\"/#SPORTIdent\">SPORTIdent</a> og <a href=\"/#EMIT\">EMIT</a>. Systemet er basert på Arduino-plattformen.",
+    "tags": ["tidtaking"],
+    "related": ["tidtaking", "SPORTIdent", "EMIT"],
+    "aliases": []
   }
 ]

--- a/resources/orienteering_dictionary.json
+++ b/resources/orienteering_dictionary.json
@@ -323,7 +323,7 @@
   },
   {
     "name": "postplukk",
-    "description": "Etter et orienteringsløp må postene hentes inn fra terrenget. Dette kalles postplukk. Vanligvis er det arrangørklubben som organiserer dette, og det er gjerne løpere som hjelper til.",
+    "description": "Postplukk er et orienteringsløp med svært mange poster tett på hverandre, slik at løperen plukker post etter post uten å løpe langt mellom hver. Formatet legger vekt på kart- og postlesing fremfor løping.",
     "tags": [],
     "related": ["orienteringspost"],
     "aliases": []
@@ -337,21 +337,21 @@
   },
   {
     "name": "startpost",
-    "description": "Startposten er den første posten i et løyp, plassert et stykke fra startstedet. Løperen navigerer selv fra start til startposten. I konkurranser er startposten ofte markert med en trekant på kartet.",
+    "description": "Startposten er den første posten i et løyp. I større løp er startposten plassert et stykke fra selve startstedet, og veien dit er markert med bånd slik at løperen ikke trenger å navigere den første biten. I mindre løp er start og startpost ofte på samme sted. Startposten er markert med en trekant på kartet.",
     "tags": [],
     "related": ["orienteringspost"],
     "aliases": []
   },
   {
     "name": "klippetang",
-    "description": "En klippetang er et manuelt stemplingsverktøy som lager et unikt mønster av hull i stempelkortet når det klemmes fast. Klippetangen er et alternativ til elektronisk tidtaking og brukes fortsatt på noen løp. Hvert post har sin egen tang med unikt mønster.",
+    "description": "En klippetang er det opprinnelige stemplingsverktøyet i orientering, brukt før elektronisk tidtaking. Den lager et unikt mønster av hull i stempelkortet når den klemmes fast. Klippetangen er i dag nesten ikke i bruk og sees svært sjelden i vanlige løp. <i>Se <a href=\"/#tidtaking\">tidtaking</a></i>.",
     "tags": ["tidtaking"],
     "related": ["tidtaking", "orienteringspost"],
     "aliases": []
   },
   {
     "name": "Sportiduino",
-    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> er et åpen kildekode-system for elektronisk tidtaking i orientering, og er et rimeligere alternativ til <a href=\"/#SPORTIdent\">SPORTIdent</a> og <a href=\"/#EMIT\">EMIT</a>. Systemet er basert på Arduino-plattformen.",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> er et åpen kildekode-system for elektronisk tidtaking i orientering, og er et rimeligere alternativ til <a href=\"/#SPORTIdent\">SPORTIdent</a> og <a href=\"/#EMIT\">EMIT</a>. Systemet er basert på Arduino-plattformen, men krever betydelig tid og innsats å sette opp da man selv må bygge poster og brikkeleser.",
     "tags": ["tidtaking"],
     "related": ["tidtaking", "SPORTIdent", "EMIT"],
     "aliases": []


### PR DESCRIPTION
Adds the five missing words listed in #37:

- **postplukk** - collecting controls after a race
- **ringen** - the circle marking the control on the map
- **startpost** - the first control in a course
- **klippetang** - manual punch used to mark control cards
- **Sportiduino** - open-source electronic timing system

Closes #37