### PR TITLE
fix: resolve 502 on /api/suggest

### DIFF
--- a/app/api/suggest/route.js
+++ b/app/api/suggest/route.js
@@ -53,6 +53,8 @@ export async function POST(request) {
   );
 
   if (!res.ok) {
+    const errorBody = await res.json().catch(() => ({}));
+    console.error("GitHub API error:", res.status, errorBody);
     return NextResponse.json(
       { error: "Failed to submit suggestion" },
       { status: 502 }


### PR DESCRIPTION
The \`word suggestion\` label did not exist in the repo. GitHub API rejects issue creation with non-existent labels, causing a 502.

**Fix:**
- Created the \`word suggestion\` label in the repo
- Added error logging so GitHub API failures are visible in Vercel logs going forward