### PR TITLE
ci: add GitHub Actions workflow to verify npm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - run: npm ci --registry=https://registry.npmjs.org/
+
+      - run: npm run build


### PR DESCRIPTION
Adds a CI workflow that runs on every push and PR to verify `npm run build` succeeds.

Vercel preview deployments are handled automatically by the Vercel GitHub app and will post a preview URL comment on each PR.