### PR TITLE
feat: add English translation of orienteering dictionary

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -84,10 +84,19 @@ const translations = {
   },
 };
 
+const langPaths = { no: "/", en: "/en/", sv: "/sv/", da: "/da/", fi: "/fi/" };
+
 const dictionaries = {
   no: require("./resources/orienteering_dictionary.json"),
   en: require("./resources/orienteering_dictionary_en.json"),
 };
+
+const dictionaryMaps = Object.fromEntries(
+  Object.entries(dictionaries).map(([locale, dict]) => [
+    locale,
+    Object.fromEntries(dict.map((e) => [e.id, e])),
+  ])
+);
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ "public/favicon.ico": "favicon.ico" });
@@ -97,6 +106,8 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addGlobalData("translations", translations);
   eleventyConfig.addGlobalData("dictionaries", dictionaries);
+  eleventyConfig.addGlobalData("dictionaryMaps", dictionaryMaps);
+  eleventyConfig.addGlobalData("langPaths", langPaths);
 
   return {
     dir: {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -21,6 +21,8 @@ const translations = {
     lightMode: "Bytt til lyst tema",
     darkMode: "Bytt til mørkt tema",
     languageLabel: "Språk",
+    showTranslations: "Vis andre språk",
+    hideTranslations: "Skjul andre språk",
   },
   en: {
     langCode: "en",
@@ -36,6 +38,8 @@ const translations = {
     lightMode: "Switch to light mode",
     darkMode: "Switch to dark mode",
     languageLabel: "Language",
+    showTranslations: "Show other languages",
+    hideTranslations: "Hide other languages",
   },
   sv: {
     langCode: "sv",
@@ -51,6 +55,8 @@ const translations = {
     lightMode: "Byt till ljust tema",
     darkMode: "Byt till mörkt tema",
     languageLabel: "Språk",
+    showTranslations: "Visa andra språk",
+    hideTranslations: "Dölj andra språk",
   },
   da: {
     langCode: "da",
@@ -66,6 +72,8 @@ const translations = {
     lightMode: "Skift til lyst tema",
     darkMode: "Skift til mørkt tema",
     languageLabel: "Sprog",
+    showTranslations: "Vis andre sprog",
+    hideTranslations: "Skjul andre sprog",
   },
   fi: {
     langCode: "fi",
@@ -81,6 +89,8 @@ const translations = {
     lightMode: "Vaihda vaaleaan teemaan",
     darkMode: "Vaihda tummaan teemaan",
     languageLabel: "Kieli",
+    showTranslations: "Näytä muut kielet",
+    hideTranslations: "Piilota muut kielet",
   },
 };
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -84,7 +84,10 @@ const translations = {
   },
 };
 
-const dictionary = require("./resources/orienteering_dictionary.json");
+const dictionaries = {
+  no: require("./resources/orienteering_dictionary.json"),
+  en: require("./resources/orienteering_dictionary_en.json"),
+};
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ "public/favicon.ico": "favicon.ico" });
@@ -93,7 +96,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("slugify", slugify);
 
   eleventyConfig.addGlobalData("translations", translations);
-  eleventyConfig.addGlobalData("dictionary", dictionary);
+  eleventyConfig.addGlobalData("dictionaries", dictionaries);
 
   return {
     dir: {

--- a/resources/orienteering_dictionary.json
+++ b/resources/orienteering_dictionary.json
@@ -4,356 +4,497 @@
     "description": "En PM (promemoria) til et orienteringsløp vil si løpsinstruksen, altså mer detaljert informasjon om løpet. F.eks. nøyaktig hvor starten er eller informasjon om matstasjoner. Det er ikke vanlig å gi ut PM ved mindre løp.",
     "tags": [],
     "related": [],
-    "aliases": ["promemoria"]
+    "aliases": [
+      "promemoria"
+    ],
+    "id": "PM"
   },
   {
     "name": "samlingsplass",
     "description": "Området hvor man finner mål, speaker, funksjonærer, dusj, resultater, premieutdeling og lignende. Starten er ofte et annet sted, men skiltet fra samlingsplass. ",
     "tags": [],
     "related": [],
-    "aliases": ["arena"]
+    "aliases": [
+      "arena"
+    ],
+    "id": "samlingsplass"
   },
   {
     "name": "kavle",
     "description": "Svensk ord for stafett i orienteringssammenheng, kan også kalles budkavle.",
-    "tags": ["stafett"],
+    "tags": [
+      "stafett"
+    ],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "kavle"
   },
   {
     "name": "bomme",
     "description": "Når man ikke treffer posten slik man ønsker og dermed taper tid, snakker man om å bomme. Å bomme for en proff kan være å miste 10-20 sekunder fordi man ikke fant posten med en gang, mens for en nybegynner snakker man ofte heller om minutter og i verste fall titalls minutter.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "bomme"
   },
   {
     "name": "EMIT",
     "description": "I norsk orientering bruker man et eletronisk tidtakersystem som produseres av det norske firmaet EMIT, <i>se <a href=\"/#tidtaking\">tidtaking</a></i>. I Sverige brukes <a href=\"/#SPORTIdent\">SportIdent</a>.",
-    "tags": ["tidtaking"],
-    "related": ["SPORTIdent", "SFR"],
-    "aliases": []
+    "tags": [
+      "tidtaking"
+    ],
+    "related": [
+      "SPORTIdent",
+      "SFR"
+    ],
+    "aliases": [],
+    "id": "EMIT"
   },
   {
     "name": "tidtaking",
     "description": "Tidtaking i orientering baserer seg på at man har en løperbrikke som er registrert på en bestemt løper. Når denne løperen kommer til en orienteringspost, legges denne løperbrikka på en stemplingsenhet, dette gjør at det blir registrert i løperbrikka at løperen har vært innom posten. Når man kommer til mål registreres løperbrikka og man får vite tiden man brukte på løypa (og mellomtiden mellom postene). De to vanligste tidtakersystemene er <a href=\"/#SPORTIdent\">SportIdent</a> og <a href=\"/#EMIT\">EMIT</a>. ",
-    "tags": ["tidtaking"],
-    "related": ["EMIT", "SPORTIdent", "SFR"],
-    "aliases": []
+    "tags": [
+      "tidtaking"
+    ],
+    "related": [
+      "EMIT",
+      "SPORTIdent",
+      "SFR"
+    ],
+    "aliases": [],
+    "id": "tidtaking"
   },
   {
     "name": "gafling",
     "description": "For å forhindre at konkurrenter følger etter hverandre (<a href=\"/#henge\">se henging</a>) når man løper, er det mulig å lage gaflede løyper. Det vil si løpere i samme klasse får løyper som er litt forskjellige. De fleste postene er som oftest like, men det kan være en post der noen løpere må ta en post som er f.eks. 50-100 meter fra en annen post som andre løpere i samme klasse må ta. Dette gjør at man må vite hvor på kartet man er så man tar riktig post, velger man feil post blir man disket.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "gafling"
   },
   {
     "name": "postbeskrivelse",
     "description": "Dette er en lapp som følger med kartet, den kan også være printet på kartet. Den har symboler som forklarer hvordan en post ligger. F.eks. at post 3 ligger vest for en stor stein. Altså detaljert postinformasjon.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "postbeskrivelse"
   },
   {
     "name": "SPORTIdent",
     "description": "Elektronisk tidtakersystem for orientering. <a href=\"https://www.sportident.com/\">SportIdent</a> er samme konsept som EMIT. Enheten man stempler med kalles for SI-brikke. SPORTIdent brukes blant annet i Sverige. <i>Se <a href=\"/#tidtaking\">tidtaking</a></i>.",
-    "tags": ["tidtaking"],
-    "related": ["EMIT", "SFR"],
-    "aliases": []
+    "tags": [
+      "tidtaking"
+    ],
+    "related": [
+      "EMIT",
+      "SFR"
+    ],
+    "aliases": [],
+    "id": "SPORTIdent"
   },
   {
     "name": "SFR",
     "description": "<a href=\"http://sfr-system.com/\">SFR</a> (Start Finish Result) er et russisk tidtakersystem for orientering. Samme konsept som EMIT.",
-    "tags": ["tidtaking"],
-    "related": ["EMIT", "SPORTIdent"],
-    "aliases": []
+    "tags": [
+      "tidtaking"
+    ],
+    "related": [
+      "EMIT",
+      "SPORTIdent"
+    ],
+    "aliases": [],
+    "id": "SFR"
   },
   {
     "name": "Rankingløp",
     "description": "Rankingløp er uformelle treningsløp som arrangeres ukentlig av OSI Orientering og IL GeoForm. For hvert løp man løper samler man poeng til en totalranking, derav navnet Rankingløp. Se mer på vår side om <a href=\"https://ilgeoform.no/rankinglop/\">rankingløp</a>.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Rankingløp"
   },
   {
     "name": "Nordmarkskarusellen",
     "description": "Nordmarkskarusellen er en samling løp rundt om i sør-enden av Nordmarka. Tre løp på våren og fire løp på høsten. Det tilbys nybegynnervennlige løyper og krevende løyper. Løpene er et samarbeid mellom klubbene OSI, Kjelsås, Heming, Lillomarka, Koll og Nydalen. Les mer på Nordmarkskarusellen sin <a href=\"http://nordmarkskarusellen.com/\">hjemmeside</a>.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Nordmarkskarusellen"
   },
   {
     "name": "Eventor",
     "description": "<a href=\"http://eventor.orientering.no\">Eventor</a> er en nettside som inneholder terminliste over alle orienteringsløp, man kan også melde seg på de fleste løpene der og resultatene fra løpene vil bli lastet opp dit. Registrer din egen bruker på siden for å melde deg på løp. Eventor er i utgangspunktet et svensk system, men er også i bruk her i Norge, i Australia og for internasjonale løp.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Eventor"
   },
   {
     "name": "kart",
     "description": "Et kart viser landskapet i mindre og forenklet format, og er det en orienteringsløper bruker for å finne frem til postene. Kartet inneholder mange symboler som viser hva som finnes i terrenget, det kan være høydekurver for å vise høydeforskjeller, svarte prikker for å vise steiner eller blå flekker for å vise vann. Norges Orienteringsforbund har lagt ut en <a href=\"http://osi-orientering.com/wp-content/uploads/2016/01/karttegn_isom_2008.pdf\">oversikt</a> over de vanligste. Kartet kan være i forskjellige <i><a href=\"/#målestokk\">målestokker</a></i>, f.eks. 1:5000 i sprint, eller ofte 1:10000 i vanlige orienteringsløp. ",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "kart"
   },
   {
     "name": "målestokk",
     "description": "Målestokk sier hvor mye et kart er skalert i forhold til virkeligheten. Om målestokken er 1:10000, betyr det at 1 cm på kartet, er 10000 cm (eller 100 meter) i virkeligheten. Turkart bruker bruker ofte en stor målestokk, 1:50000 er vanlig, det betyr at kartet viser et stort område (skalert mye). I orientering er det sjelden brukt større målestokk enn 1:15000, og 1:7500 og 1:10000 er vanlig. Når målstokken er liten, f.eks. 1:7500, kan man få plass til flere detaljer på kartet, og det blir ofte lettere å orientere presist.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "målestokk"
   },
   {
     "name": "kompass",
     "description": "Et kompass viser hvor nord og sør er (og dermed vet man også hvor øst og vest er). Dette gjør at en orienteringsløper kan bruke kompasset til å for eksempel holde rett kurs mot nord (dersom nord er den riktige veien til den neste <i><a href=\"/#orienteringspost\">posten</a></i>). Eller man kan bruke kompasset til å orientere kartet (det vil si å få kartet til å stemme med virkeligheten).",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "kompass"
   },
   {
     "name": "orienteringspost",
     "description": "En orienteringspost (kalt bare post eller flagg) er en postskjerm med en tilhørende stemplingsenhet. <i>Se <a href=\"/#tidtaking\">tidtaking</a></i>.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "orienteringspost"
   },
   {
     "name": "tommelkompass",
     "description": "Et kompass som kan festes på tommelen, det er slike kompass som er vanligst blant orienteringsløpere. De tradisjonelle kompassene kalles platekompass. <i>Se <a href=\"/#kompass\">kompass</a></i>",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "tommelkompass"
   },
   {
     "name": "A-nivå",
     "description": "Det mest krevende nivået for en orienteringsløype, her bør alle orienteringsteknikker beherskes.. <i>Se <a href=\"/#vanskelighetsgrad\">vanskelighetsgrad</a></i>",
     "tags": [],
-    "related": ["B-nivå", "C-nivå", "N-nivå"],
-    "aliases": []
+    "related": [
+      "B-nivå",
+      "C-nivå",
+      "N-nivå"
+    ],
+    "aliases": [],
+    "id": "A-nivå"
   },
   {
     "name": "B-nivå",
     "description": "Det nest vanskeligste nivået for en orienteringsløype. B-løyper krever kort finorientering inn mot posten og forståelse av høydekurver. <i>Se <a href=\"/#vanskelighetsgrad\">vanskelighetsgrad</a></i>",
     "tags": [],
-    "related": ["A-nivå", "C-nivå", "N-nivå"],
-    "aliases": []
+    "related": [
+      "A-nivå",
+      "C-nivå",
+      "N-nivå"
+    ],
+    "aliases": [],
+    "id": "B-nivå"
   },
   {
     "name": "C-nivå",
     "description": "Det nest enkleste nivået for en orienteringsløype. C-løyper følger stort sett <a href=\"/#ledelinje\">ledelinjer</a>, men enkelt steder forventes løperne å forlate ledelinjene. Det kan finnes veivalgsmuligheter.<i>Se <a href=\"/#vanskelighetsgrad\">vanskelighetsgrad</a></i>",
     "tags": [],
-    "related": ["A-nivå", "B-nivå", "N-nivå"],
-    "aliases": []
+    "related": [
+      "A-nivå",
+      "B-nivå",
+      "N-nivå"
+    ],
+    "aliases": [],
+    "id": "C-nivå"
   },
   {
     "name": "N-nivå",
     "description": "Det enkleste nivået for en orienteringsløype, nybegynnervennlig. N-løyper har ett opplagt veivalg langs sammenhengende <a href=\"/#ledelinje\">ledelinjer</a> som vei, sti, bekk og gjerde. Alle postene kan sees fra ledelinjene. <i>Se <a href=\"/#vanskelighetsgrad\">vanskelighetsgrad</a></i>",
     "tags": [],
-    "related": ["A-nivå", "B-nivå", "C-nivå"],
-    "aliases": []
+    "related": [
+      "A-nivå",
+      "B-nivå",
+      "C-nivå"
+    ],
+    "aliases": [],
+    "id": "N-nivå"
   },
   {
     "name": "vanskelighetsgrad",
     "description": "En løype i orientering deles inn i fire vanskelighetsgrader, <a href=\"/#A-niv\">A</a>, <a href=\"/#B-niv\">B</a>, <a href=\"/#C-niv\">C</a> og <a href=\"/#N-niv\">N</a>. Der A er vanskeligst, B er litt lettere, C enda litt lettere og N er nybegynnerløyper.",
     "tags": [],
-    "related": ["A-nivå", "B-nivå", "C-nivå", "N-nivå"],
-    "aliases": []
+    "related": [
+      "A-nivå",
+      "B-nivå",
+      "C-nivå",
+      "N-nivå"
+    ],
+    "aliases": [],
+    "id": "vanskelighetsgrad"
   },
   {
     "name": "henge",
     "description": "Det å henge betyr å følge etter en annen orienteringsløper uten å bruke sitt eget kart til å finne frem. Dette er sett på som dårlig stil i orientering.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "henge"
   },
   {
     "name": "D",
     "description": "D står for Dame, f.eks. D17- betyr damer over 17 år. Brukes under påmelding til orienteringsløp og i resultatlister.",
     "tags": [],
-    "related": ["H"],
-    "aliases": []
+    "related": [
+      "H"
+    ],
+    "aliases": [],
+    "id": "D"
   },
   {
     "name": "H",
     "description": "H står for Herre. F.eks. H17- betyr menn over 17 år. Brukes i påmelding til orienteringsløp og i resultatlister.",
     "tags": [],
-    "related": ["D"],
-    "aliases": []
+    "related": [
+      "D"
+    ],
+    "aliases": [],
+    "id": "H"
   },
   {
     "name": "O",
     "description": "I orientering er man glad i bokstaven O, og denne bruker man så ofte man har mulighet. o-sko (<a href=\"/#orienteringssko\">orienteringssko</a>), o-trening (orienteringstrening), o-hilsen (orienteringshilsen, altså istedenfor <i>hilsen Truls</i> blir det <i>o-hilsen Truls</i>), o-prikker (når du har løpt i skikkelig kvistkvas vil armene dine få o-prikker), o-sporten, o-løp osv. ",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "O"
   },
   {
     "name": "orienteringssko",
     "description": "I orientering bruker man sko med grove knaster under skoen og ofte også med pigger i sålen for best mulig grep på sleipt underlag, også fint å bruke under isete forhold.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "orienteringssko"
   },
   {
     "name": "ledelinje",
     "description": "En ledelinje er noe som det er enkelt å se og følge på kartet, såvel som i naturen. Eksempler på en ledelinjer kan være bekker, stier eller kanten av et jorde. Alle disse er enkle å se på kartet, og man kan enkelt følge dem i terrenget. En ledelinje leder deg trygt fra et sted til et annet, eller det kan være noe du helt sikkert treffer på om du kommer vinkelrett mot den (også kalt et sikkert oppfang, noe som fanger deg opp om du løper rett på).",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "ledelinje"
   },
   {
     "name": "georeferere",
     "description": "Et orienteringskart kan georefereres, det vil si å samkjøre kartet med det nasjonale koordinatsystemet. Dette kan for eksempel gjøres ved å kalibrere kartet mot Google Maps, slik at man i teorien kunne byttet ut en flik av Google Maps med det aktuelle orienteringskartet. Dette er nyttig for eksempel når man ønsker å legge et GPS spor oppå kartet for å se hvor man har løpt (f.eks. om man har brukt en klokke med GPS). GPS-en baserer seg på koordinater, og da er det nødvendig at orienteringskartet har koordinater som er samkjørt med det samme koordinatsystemet som GPS-en bruker.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "georeferere"
   },
   {
     "name": "Kjempesprekken",
     "description": "Dette er årets OSI Orientering høydepunkt. Kjempesprekken er et langt tradisjonsløp som starter med utgangspunkt i KSI-hytta. I starten var det bare 30 km og 18 km, men etter hvert kom 12 km og 6 km til, og 30 km forsvant. I dag er det 18 km, 12 km og 6 km løyper i nydelig Nordmarka-natur. Det er bankett med klubbens medlemmer etter løpet på KSI-hytta.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Kjempesprekken"
   },
   {
     "name": "Tiomila ",
     "description": "Et av Skandinavias største og råeste stafettløp i orientering. Stafetten holdes i Sverige om våren, hvor damene løper etapper på dagen (5 etapper) og herrene løper etapper på natten (10 etapper). ",
-    "tags": ["stafett"],
-    "related": ["Jukola", "Night Hawk"],
-    "aliases": []
+    "tags": [
+      "stafett"
+    ],
+    "related": [
+      "Jukola",
+      "Night Hawk"
+    ],
+    "aliases": [],
+    "id": "Tiomila"
   },
   {
     "name": "Jukola",
     "description": "Jukola er en av verdens største orienteringsstafetter, med rundt 15 000 deltakere. Jukola arrangeres i Finland i juni måned. Damene løper på dagtid (4 etapper) og herrene på natta (7 etapper).",
-    "tags": ["stafett"],
-    "related": ["Tiomila", "Night Hawk"],
-    "aliases": []
+    "tags": [
+      "stafett"
+    ],
+    "related": [
+      "Tiomila",
+      "Night Hawk"
+    ],
+    "aliases": [],
+    "id": "Jukola"
   },
   {
     "name": "Night Hawk",
     "description": "I Sverige har man Tiomila, i Finland har man Jukola, i Norge er det Night Hawk som gjelder. En stor orienteringsstafett som går i august. Damene har 6 etapper og herrene har 8 etapper. For både damer og herrer er halvparten av etappene på natta, og den andre halvparten på dagen.",
-    "tags": ["stafett"],
-    "related": ["Tiomila", "Jukola"],
-    "aliases": []
+    "tags": [
+      "stafett"
+    ],
+    "related": [
+      "Tiomila",
+      "Jukola"
+    ],
+    "aliases": [],
+    "id": "Night Hawk"
   },
   {
     "name": "nattorientering",
     "description": "Orientering i mørket. For mange orienteringsløpere er nattorientering mer fascinerende enn å finne frem i dagslys. Å oppfatte detaljer i terrenget rundt deg i lyset fra en hodelykt er helt annerledes enn å se seg rundt i dagslys. Det blir enda viktigere å vite nøyaktig hvor på kartet en er for å vite hvilke detaljer en skal se etter rundt seg. Å vite at en nærmer seg en post for så se reflekslyset fra posten, gir en god mestringsfølelse.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "nattorientering"
   },
   {
     "name": "bryte",
     "description": "Om man skader seg, eller man roter seg så bort at man ikke klarer å finne neste post, er alternativet å bryte. Dette vil si å avbryte løpet og finne raskeste vei tilbake til <a href=\"/#samlingsplass\">samlingsplass</a> (da er det viktig å registrere seg i mål likevel, ellers kan det oppstå leteaksjon etter savnede løpere). Løpere som bryter vil bli oppført som DNF (Did Not Finish) på resultatlista.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "bryte"
   },
   {
     "name": "direkteklasser",
     "description": "Direkteklasser er klasser der man kan melde seg på ved oppmøte på konkurransedagen, man behøver altså ikke å forhåndspåmelde seg. Det er vanligvis ikke alders eller kjønnsinndeling i disse klassene. Direktepåmelding er praktisk for etternølere.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "direkteklasser"
   },
   {
     "name": "presisjonsorientering",
     "description": "Presisjonsorientering er en gren innen orientering som er lagt til rette for både funksjonsfriske og bevegelsehemmede. Løypene skal gå langs stier eller veier som er tilgjengelig for rullestol. I terrenget langs løypa er det plassert et antall poster, som skal løses korrekt. På en normal post er det plassert et antall skjermer, og man skal bestemme hvilken (om noen) som er riktig ifølge kart og postbeskrivelse. Det finnes også enskjermsposter, hvor deltageren skal bestemme hvilken (om noen) av flere postbeskrivelser som er korrekt.",
     "tags": [],
     "related": [],
-    "aliases": ["pre-o"]
+    "aliases": [
+      "pre-o"
+    ],
+    "id": "presisjonsorientering"
   },
   {
     "name": "småtroll",
     "description": "Småtroll er løyper for de aller minste. Disse er merket og gjør gjerne noe ut av at postene skal være mer interessante enn bare o-skjermer. Løypene kan også være av mer hinder-aktig art, ikke særlig fokus på kart (og dette er heller ikke nødvendig for å komme gjennom løypa). Som regel premie til alle når man har kommet seg gjennom løypa.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "småtroll"
   },
   {
     "name": "ekvidistanse",
     "description": "Ekvidistanse er høydeforskjellen mellom to høydekurver (som er de brune strekene på kartet). Ekvidistansen avgjør hvor detaljert høyder kan vises i kartet, er for eksempel ekvidistansen 2.5 meter vil alle høydeforskjeller større enn 2.5 meter kunne vises med høydekurver på kartet. Er derimot ekvidistansen 20 meter, kan kun alle høydeforskjeller på 20 meter eller større vises med høydekurver på kartet. Det vanlige på orienteringskart er 5 meter. Se <a href=\"/#tellekurve\">tellekurve</a>",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "ekvidistanse"
   },
   {
     "name": "tellekurve",
     "description": "Hver 5. høydekurve på et kart vil være litt tykkere, dette er en tellekurve. Disse brukes for rask og enkelt å kunne regne ut større høydeforskjeller i terrenget. Er for eksempel <a href=\"/#ekvidistanse\">ekvidistansen</a> 5 meter, betyr det at det er 25 høydemeter (5 meter ekvidistanse x 5 høydekurver) mellom hver tellekurve, og om det er 3 tellekurver mellom deg og neste post betyr det at det er 75 høydemeter å klatre (3 tellekurver x 25 meter).",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "tellekurve"
   },
   {
     "name": "OSI",
     "description": "Oslostudentenes Idrettsklubb. Også forkortet Oslostudentenes IK",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "OSI"
   },
   {
     "name": "turorientering",
     "description": "Turorientering er orientering i ditt eget tempo når du vil. Du kjøper et kart med inntegnede poster, disse postene er i skogen hele sommerhalvåret, og du kan gå/løpe til dem når du ønsker. Postene har en kode ved seg som du kan registrere på <a href=\"http://turorientering.no/\">turorientering.no</a> for å stige på poenglistene.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "turorientering"
   },
   {
     "name": "Stolpejakten",
     "description": "Stolpejakten er et gratis tilbud som går ut på å finne stolper sentralt plassert i ulike kommuner. Stolpene kan registreres både ved å laste ned en app på telefonen der man enten scanner QR-koden eller skriver inn koden som hver stolpe er utstyrt med. Kart over stolpene kan lastes ned (og selv skrives ut) fra deres nettsider, eventuelt kan man bruke kartet i appen. Stolpejakten er veldig likt <a href=\"#turorientering\">turorientering</a>, men er som oftest i mer urbane strøk. Les mer på <a href=\"https://www.stolpejakten.no/#/about\">Stolpejakten.no</a>\n",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Stolpejakten"
   },
   {
     "name": "nulle",
     "description": "Å nulle betyr å nullstille sin personlige tidtakerbrikke. Dette betyr å fjerne gamle løp, og må gjøres før man starter på et nytt løp. Om man glemmer å nulle vil man ikke få riktig tid og blir derfor disket.",
-    "tags": ["tidtaking"],
+    "tags": [
+      "tidtaking"
+    ],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "nulle"
   },
   {
     "name": "Livelox",
     "description": "<a href=\"https://www.livelox.com/\">Livelox</a> er en nettside der det er mulig å analysere og se hvor man har løpt på et orienteringsløp. Dette gjør man ved at arrangøren laster opp kartet på forhånd, og at utøverne etter løpet kan laste opp sine GPS-spor (som man enten har brukt mobilen eller en klokke med GPS til å lage). Det finnes flere andre slike tjenester (f.eks. <a href=\"http://3drerun.worldofo.com/\">3D Rerun</a> og <a href=\"http://www.opath.se/\">OPath</a>), men Livelox er den mest utbredte.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Livelox"
   },
   {
     "name": "postplukk",
     "description": "Postplukk er et orienteringsløp med svært mange poster tett på hverandre, slik at løperen plukker post etter post uten å løpe langt mellom hver. Formatet legger vekt på kart- og postlesing fremfor løping.",
     "tags": [],
-    "related": ["orienteringspost"],
-    "aliases": []
+    "related": [
+      "orienteringspost"
+    ],
+    "aliases": [],
+    "id": "postplukk"
   },
   {
     "name": "ringen",
     "description": "Ringen er sirkelen som markerer postens nøyaktige posisjon på orienteringskartet. Sirkelen er tegnet rundt det eksakte punktet som skal oppsøkes. <i>Se også <a href=\"/#postbeskrivelse\">postbeskrivelse</a></i>.",
     "tags": [],
-    "related": ["kart", "orienteringspost", "postbeskrivelse"],
-    "aliases": []
+    "related": [
+      "kart",
+      "orienteringspost",
+      "postbeskrivelse"
+    ],
+    "aliases": [],
+    "id": "ringen"
   },
   {
     "name": "startpost",
     "description": "Startposten er den første posten i et løyp. I større løp er startposten plassert et stykke fra selve startstedet, og veien dit er markert med bånd slik at løperen ikke trenger å navigere den første biten. I mindre løp er start og startpost ofte på samme sted. Startposten er markert med en trekant på kartet.",
     "tags": [],
-    "related": ["orienteringspost"],
-    "aliases": []
+    "related": [
+      "orienteringspost"
+    ],
+    "aliases": [],
+    "id": "startpost"
   },
   {
     "name": "klippetang",
     "description": "En klippetang er det opprinnelige stemplingsverktøyet i orientering, brukt før elektronisk tidtaking. Den lager et unikt mønster av hull i stempelkortet når den klemmes fast. Klippetangen er i dag nesten ikke i bruk og sees svært sjelden i vanlige løp. <i>Se <a href=\"/#tidtaking\">tidtaking</a></i>.",
-    "tags": ["tidtaking"],
-    "related": ["tidtaking", "orienteringspost"],
-    "aliases": []
+    "tags": [
+      "tidtaking"
+    ],
+    "related": [
+      "tidtaking",
+      "orienteringspost"
+    ],
+    "aliases": [],
+    "id": "klippetang"
   },
   {
     "name": "Sportiduino",
     "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> er et åpen kildekode-system for elektronisk tidtaking i orientering, og er et rimeligere alternativ til <a href=\"/#SPORTIdent\">SPORTIdent</a> og <a href=\"/#EMIT\">EMIT</a>. Systemet er basert på Arduino-plattformen, men krever betydelig tid og innsats å sette opp da man selv må bygge poster og brikkeleser.",
-    "tags": ["tidtaking"],
-    "related": ["tidtaking", "SPORTIdent", "EMIT"],
-    "aliases": []
+    "tags": [
+      "tidtaking"
+    ],
+    "related": [
+      "tidtaking",
+      "SPORTIdent",
+      "EMIT"
+    ],
+    "aliases": [],
+    "id": "Sportiduino"
   }
 ]

--- a/resources/orienteering_dictionary_en.json
+++ b/resources/orienteering_dictionary_en.json
@@ -4,356 +4,538 @@
     "description": "A PM (from Latin <i>pro memoria</i>) for an orienteering event is the event programme or race instructions — detailed information such as the exact start location, parking directions, and water station details. A PM is typically only produced for larger events.",
     "tags": [],
     "related": [],
-    "aliases": ["promemoria", "event programme", "race instructions"]
+    "aliases": [
+      "promemoria",
+      "event programme",
+      "race instructions"
+    ],
+    "id": "PM"
   },
   {
     "name": "event centre",
     "description": "The event centre (also called the arena) is the central hub of an orienteering event. Here you will find the finish, download station, officials, results boards, presentations, and often showers or refreshments. The start is often located elsewhere but is signposted from the event centre.",
     "tags": [],
     "related": [],
-    "aliases": ["arena"]
+    "aliases": [
+      "arena"
+    ],
+    "id": "samlingsplass"
   },
   {
     "name": "relay",
     "description": "A relay (known in Scandinavian orienteering as <i>kavle</i> or <i>budkavle</i>) is a team format where each team member runs one or more legs of the course, handing over to the next team member at the end of their leg.",
-    "tags": ["relay"],
+    "tags": [
+      "relay"
+    ],
     "related": [],
-    "aliases": ["kavle", "budkavle"]
+    "aliases": [
+      "kavle",
+      "budkavle"
+    ],
+    "id": "kavle"
   },
   {
     "name": "error",
     "description": "An error (or mistake) occurs when a competitor fails to navigate precisely to a control and loses time as a result. For elite runners, an error might mean losing 10–20 seconds; for beginners, errors can cost several minutes or more.",
     "tags": [],
     "related": [],
-    "aliases": ["mistake"]
+    "aliases": [
+      "mistake"
+    ],
+    "id": "bomme"
   },
   {
     "name": "EMIT",
     "description": "EMIT is an electronic timing system for orienteering produced by the Norwegian company EMIT. It is the most common timing system used in Norway. Internationally, <a href=\"/#sportident\">SPORTIdent</a> is the more widely used standard. <i>See <a href=\"/#timing\">timing</a></i>.",
-    "tags": ["timing"],
-    "related": ["SPORTIdent", "SFR"],
-    "aliases": []
+    "tags": [
+      "timing"
+    ],
+    "related": [
+      "SPORTIdent",
+      "SFR"
+    ],
+    "aliases": [],
+    "id": "EMIT"
   },
   {
     "name": "timing",
     "description": "Electronic timing in orienteering works via a personal timing chip registered to each competitor. When a runner arrives at a control, they punch their chip on the timing unit at that control, recording the visit. At the finish the chip is downloaded and the total time and split times between controls are displayed. The two most common systems are <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>.",
-    "tags": ["timing"],
-    "related": ["EMIT", "SPORTIdent", "SFR"],
-    "aliases": []
+    "tags": [
+      "timing"
+    ],
+    "related": [
+      "EMIT",
+      "SPORTIdent",
+      "SFR"
+    ],
+    "aliases": [],
+    "id": "tidtaking"
   },
   {
     "name": "forking",
     "description": "Forking is used to prevent competitors from <a href=\"/#following\">following</a> each other around the course. Runners in the same class receive courses that differ slightly — most controls are shared, but at certain points some runners must visit a control a short distance away from the one others in the same class visit. Runners must navigate carefully to punch the correct control; punching the wrong one results in disqualification.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "gafling"
   },
   {
     "name": "control description",
     "description": "A control description (also called a clue sheet) is a slip attached to the map or printed directly on it. It uses standardised IOF symbols to specify exactly what feature each control is placed on — for example, that control 3 is on the west side of a large boulder.",
     "tags": [],
     "related": [],
-    "aliases": ["clue sheet"]
+    "aliases": [
+      "clue sheet"
+    ],
+    "id": "postbeskrivelse"
   },
   {
     "name": "SPORTIdent",
     "description": "<a href=\"https://www.sportident.com/\">SPORTIdent</a> is the most widely used electronic timing system in international orienteering. The personal chip is called an SI-card (or dibber in the UK). SPORTIdent is the standard at World Championships and the dominant system across Europe, the UK, and Australia. <i>See <a href=\"/#timing\">timing</a></i>.",
-    "tags": ["timing"],
-    "related": ["EMIT", "SFR"],
-    "aliases": ["SI"]
+    "tags": [
+      "timing"
+    ],
+    "related": [
+      "EMIT",
+      "SFR"
+    ],
+    "aliases": [
+      "SI"
+    ],
+    "id": "SPORTIdent"
   },
   {
     "name": "SFR",
     "description": "<a href=\"http://sfr-system.com/\">SFR</a> (Start Finish Result) is a Russian electronic timing system for orienteering, working on the same principle as SPORTIdent and EMIT.",
-    "tags": ["timing"],
-    "related": ["EMIT", "SPORTIdent"],
-    "aliases": []
+    "tags": [
+      "timing"
+    ],
+    "related": [
+      "EMIT",
+      "SPORTIdent"
+    ],
+    "aliases": [],
+    "id": "SFR"
   },
   {
     "name": "Rankingløp",
     "description": "Rankingløp is an informal training race series organised weekly by OSI Orientering and IL GeoForm in Oslo. Points are accumulated over the season to build a total ranking — hence the name. See the <a href=\"https://ilgeoform.no/rankinglop/\">Rankingløp page</a> for more information.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Rankingløp"
   },
   {
     "name": "Nordmarkskarusellen",
     "description": "Nordmarkskarusellen is a series of events held in the southern part of Nordmarka, Oslo — three races in spring and four in autumn. Both beginner-friendly and challenging courses are offered. The series is a collaboration between the clubs OSI, Kjelsås, Heming, Lillomarka, Koll, and Nydalen. More information at the <a href=\"http://nordmarkskarusellen.com/\">Nordmarkskarusellen website</a>.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Nordmarkskarusellen"
   },
   {
     "name": "Eventor",
     "description": "<a href=\"http://eventor.orientering.no\">Eventor</a> is an online platform listing orienteering events, supporting online entry, and publishing results. Originally developed in Sweden, it is also used in Norway, Australia, and for international events. Register an account to enter events online.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Eventor"
   },
   {
     "name": "map",
     "description": "An orienteering map shows the terrain in a simplified format and is the primary tool a runner uses to navigate between controls. It uses a rich set of symbols: contour lines show elevation, black dots indicate boulders, blue areas show water, and so on. Maps are produced at different <i><a href=\"/#scale\">scales</a></i>, typically 1:5000 for sprint orienteering and 1:10000 for forest orienteering.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "kart"
   },
   {
     "name": "scale",
     "description": "The scale of a map describes how much the real world has been reduced. A scale of 1:10000 means 1 cm on the map represents 10000 cm (100 metres) on the ground. Hiking maps often use scales such as 1:50000, covering a large area with limited detail. Orienteering maps are typically 1:7500 or 1:10000 for forest courses and 1:5000 or 1:4000 for sprint. A larger scale (smaller denominator) allows more terrain detail to be shown, enabling more precise navigation.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "målestokk"
   },
   {
     "name": "compass",
     "description": "A compass indicates the direction of north (and therefore south, east, and west). An orienteer uses a compass to hold a bearing towards the next <i><a href=\"/#control\">control</a></i>, or to set the map — rotating it to align with the surrounding terrain.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "kompass"
   },
   {
     "name": "control",
     "description": "An orienteering control (also called a flag or post) consists of an orange-and-white marker flag and an attached timing unit used to record a competitor's visit to that point. <i>See <a href=\"/#timing\">timing</a></i>.",
     "tags": [],
     "related": [],
-    "aliases": ["flag", "post"]
+    "aliases": [
+      "flag",
+      "post"
+    ],
+    "id": "orienteringspost"
   },
   {
     "name": "thumb compass",
     "description": "A thumb compass is strapped to the thumb, allowing the runner to hold the map and compass together as one unit — the most popular style among orienteers. Traditional plate compasses are also used but are less common in competition. <i>See <a href=\"/#compass\">compass</a></i>.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "tommelkompass"
   },
   {
     "name": "A-level",
     "description": "A-level is the most technically demanding course difficulty in the Scandinavian grading system. All orienteering techniques are required. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
     "tags": [],
-    "related": ["B-level", "C-level", "N-level"],
-    "aliases": []
+    "related": [
+      "B-level",
+      "C-level",
+      "N-level"
+    ],
+    "aliases": [],
+    "id": "A-nivå"
   },
   {
     "name": "B-level",
     "description": "B-level is the second most difficult course grade in the Scandinavian grading system. B-level courses require short fine-navigation legs into the control and a good understanding of contour lines. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
     "tags": [],
-    "related": ["A-level", "C-level", "N-level"],
-    "aliases": []
+    "related": [
+      "A-level",
+      "C-level",
+      "N-level"
+    ],
+    "aliases": [],
+    "id": "B-nivå"
   },
   {
     "name": "C-level",
     "description": "C-level is the second easiest course grade in the Scandinavian grading system. C-level courses mostly follow <a href=\"/#handrail\">handrails</a>, but runners are expected to leave handrails at certain points. Route choice opportunities may exist. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
     "tags": [],
-    "related": ["A-level", "B-level", "N-level"],
-    "aliases": []
+    "related": [
+      "A-level",
+      "B-level",
+      "N-level"
+    ],
+    "aliases": [],
+    "id": "C-nivå"
   },
   {
     "name": "N-level",
     "description": "N-level is the easiest course grade in the Scandinavian grading system, designed for beginners. N-level courses follow continuous <a href=\"/#handrail\">handrails</a> such as paths, tracks, streams, and fences, with all controls visible from the handrail. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
     "tags": [],
-    "related": ["A-level", "B-level", "C-level"],
-    "aliases": []
+    "related": [
+      "A-level",
+      "B-level",
+      "C-level"
+    ],
+    "aliases": [],
+    "id": "N-nivå"
   },
   {
     "name": "difficulty level",
     "description": "In the Scandinavian grading system, courses are divided into four difficulty levels: <a href=\"/#a-level\">A</a>, <a href=\"/#b-level\">B</a>, <a href=\"/#c-level\">C</a>, and <a href=\"/#n-level\">N</a>, where A is the hardest and N is a beginner course. Other countries use colour-coded systems — the UK uses White, Yellow, Orange, Light Green, Green, Blue, and Brown; Australia uses White, Yellow, Orange, Red, and Blue.",
     "tags": [],
-    "related": ["A-level", "B-level", "C-level", "N-level"],
-    "aliases": []
+    "related": [
+      "A-level",
+      "B-level",
+      "C-level",
+      "N-level"
+    ],
+    "aliases": [],
+    "id": "vanskelighetsgrad"
   },
   {
     "name": "following",
     "description": "Following means trailing another orienteer and navigating using their decisions rather than your own map reading. This is considered poor sportsmanship in orienteering.",
     "tags": [],
     "related": [],
-    "aliases": ["tailing", "shadowing"]
+    "aliases": [
+      "tailing",
+      "shadowing"
+    ],
+    "id": "henge"
   },
   {
     "name": "W",
     "description": "W stands for Women, used in English-language class designations (e.g. W21E for elite women aged 21 and over). In Scandinavian events you will see D instead, from the Swedish/Norwegian word <i>Dame/Damer</i>.",
     "tags": [],
-    "related": ["M"],
-    "aliases": ["D"]
+    "related": [
+      "M"
+    ],
+    "aliases": [
+      "D"
+    ],
+    "id": "D"
   },
   {
     "name": "M",
     "description": "M stands for Men, used in English-language class designations (e.g. M21E for elite men aged 21 and over). In Scandinavian events you will see H instead, from the Swedish/Norwegian word <i>Herre/Herrer</i>.",
     "tags": [],
-    "related": ["W"],
-    "aliases": ["H"]
+    "related": [
+      "W"
+    ],
+    "aliases": [
+      "H"
+    ],
+    "id": "H"
   },
   {
     "name": "O",
     "description": "Orienteers love the letter O and use it wherever possible: o-shoes (<a href=\"/#orienteering-shoes\">orienteering shoes</a>), o-training (orienteering training), o-suit, o-sport, and so on. It is shorthand for orienteering and is widely used in English-speaking clubs as well as Scandinavian ones.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "O"
   },
   {
     "name": "orienteering shoes",
     "description": "Orienteering shoes have aggressive lugged soles and are often fitted with metal spikes for the best possible grip on slippery terrain, wet roots, and icy ground.",
     "tags": [],
     "related": [],
-    "aliases": ["o-shoes"]
+    "aliases": [
+      "o-shoes"
+    ],
+    "id": "orienteringssko"
   },
   {
     "name": "handrail",
     "description": "A handrail is a linear feature that is easy to identify on the map and easy to follow in the terrain — examples include streams, paths, field edges, and fences. A handrail guides you safely from one place to another and can also act as a catching feature: a line you will inevitably cross if you overshoot your target.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "ledelinje"
   },
   {
     "name": "georeferencing",
     "description": "Georeferencing an orienteering map means aligning it with a standard coordinate system (such as WGS84). This allows GPS tracks recorded on a watch or phone to be overlaid accurately on the map for post-race route analysis. Without georeferencing, a GPS track and the map cannot be reliably aligned.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "georeferere"
   },
   {
     "name": "Kjempesprekken",
     "description": "Kjempesprekken is the highlight of OSI Orientering's year — a long-standing traditional event starting near the KSI hut in Nordmarka, Oslo. Courses of 18 km, 12 km, and 6 km wind through beautiful Nordmarka terrain. A club banquet follows the race at the KSI hut.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Kjempesprekken"
   },
   {
     "name": "Tiomila",
     "description": "One of Scandinavia's biggest and most prestigious orienteering relays, held in Sweden each spring. Women compete during the day (5 legs) and men run through the night (10 legs).",
-    "tags": ["relay"],
-    "related": ["Jukola", "Night Hawk"],
-    "aliases": []
+    "tags": [
+      "relay"
+    ],
+    "related": [
+      "Jukola",
+      "Night Hawk"
+    ],
+    "aliases": [],
+    "id": "Tiomila"
   },
   {
     "name": "Jukola",
     "description": "Jukola is one of the world's largest orienteering relays, with around 15 000 competitors. Held in Finland each June, women race during the day (4 legs) and men race through the night (7 legs).",
-    "tags": ["relay"],
-    "related": ["Tiomila", "Night Hawk"],
-    "aliases": []
+    "tags": [
+      "relay"
+    ],
+    "related": [
+      "Tiomila",
+      "Night Hawk"
+    ],
+    "aliases": [],
+    "id": "Jukola"
   },
   {
     "name": "Night Hawk",
     "description": "Night Hawk is Norway's equivalent of Tiomila and Jukola — a major orienteering relay held in August. Women run 6 legs and men run 8 legs, with roughly half of each relay taking place in darkness and the other half in daylight.",
-    "tags": ["relay"],
-    "related": ["Tiomila", "Jukola"],
-    "aliases": []
+    "tags": [
+      "relay"
+    ],
+    "related": [
+      "Tiomila",
+      "Jukola"
+    ],
+    "aliases": [],
+    "id": "Night Hawk"
   },
   {
     "name": "night orienteering",
     "description": "Orienteering in the dark. Many orienteers find night orienteering more absorbing than daylight running — navigating by headtorch demands much greater concentration and map contact. Knowing your precise position on the map matters even more when the visible world is restricted to the beam of your torch. Spotting the reflective marker of a control in the darkness gives a great sense of achievement.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "nattorientering"
   },
   {
     "name": "retire",
     "description": "If you are injured or hopelessly lost, you may retire from the race. Find the quickest safe route back to the <a href=\"/#event-centre\">event centre</a>. It is essential to report to the finish or download station even when retiring, so officials know you are safe and do not launch a search. Runners who retire are recorded as DNF (Did Not Finish) on the results.",
     "tags": [],
     "related": [],
-    "aliases": ["DNF"]
+    "aliases": [
+      "DNF"
+    ],
+    "id": "bryte"
   },
   {
     "name": "open entry",
     "description": "Open entry (or direct start) classes are courses that can be entered on the day at the event without advance registration. There is typically no age or gender split in these classes. They are ideal for newcomers or anyone who missed the entry deadline.",
     "tags": [],
     "related": [],
-    "aliases": ["direct start", "direct entry"]
+    "aliases": [
+      "direct start",
+      "direct entry"
+    ],
+    "id": "direkteklasser"
   },
   {
     "name": "trail orienteering",
     "description": "Trail orienteering (pre-O) is the IOF-recognised discipline designed to be accessible to both able-bodied and mobility-impaired participants. Courses follow paths and tracks accessible by wheelchair. The challenge is map-reading accuracy rather than running speed — at each control site, several markers are placed and the competitor must identify which one (if any) matches the map and <a href=\"/#control-description\">control description</a>. Some controls have a single marker where the task is to decide which of several control descriptions is correct.",
     "tags": [],
     "related": [],
-    "aliases": ["pre-O", "precision orienteering"]
+    "aliases": [
+      "pre-O",
+      "precision orienteering"
+    ],
+    "id": "presisjonsorientering"
   },
   {
     "name": "children's courses",
     "description": "Children's courses (known in Norway as <i>småtroll</i>, meaning 'little trolls') are designed for the very youngest participants. They are marked routes featuring fun, engaging controls rather than standard orienteering flags, with an emphasis on enjoyment and adventure over precise map reading. All finishers typically receive a prize.",
     "tags": [],
     "related": [],
-    "aliases": ["småtroll"]
+    "aliases": [
+      "småtroll"
+    ],
+    "id": "småtroll"
   },
   {
     "name": "contour interval",
     "description": "The contour interval is the difference in elevation between two adjacent contour lines (the brown lines on an orienteering map). A smaller contour interval allows more elevation detail to be shown. On most orienteering maps the contour interval is 5 metres. See <a href=\"/#index-contour\">index contour</a>.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "ekvidistanse"
   },
   {
     "name": "index contour",
     "description": "Every fifth contour line on a map is drawn thicker — this is an index contour. Index contours make it quick and easy to calculate larger height differences. With a <a href=\"/#contour-interval\">contour interval</a> of 5 metres, each index contour represents 25 metres of elevation. Three index contours between you and your next control therefore means 75 metres of climbing.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "tellekurve"
   },
   {
     "name": "OSI",
     "description": "OSI stands for Oslostudentenes Idrettsklubb (Oslo Students' Sports Club). The orienteering branch, OSI Orientering, organises events and training in and around Oslo.",
     "tags": [],
     "related": [],
-    "aliases": ["Oslostudentenes Idrettsklubb", "Oslostudentenes IK"]
+    "aliases": [
+      "Oslostudentenes Idrettsklubb",
+      "Oslostudentenes IK"
+    ],
+    "id": "OSI"
   },
   {
     "name": "permanent course",
     "description": "A permanent course is an orienteering course you can complete at your own pace, whenever you like throughout the season. You purchase or download a map with the controls marked; the controls remain in the forest for months. Controls are typically coded and visits can be logged on platforms such as <a href=\"http://turorientering.no/\">turorientering.no</a> to track your progress.",
     "tags": [],
     "related": [],
-    "aliases": ["turorientering"]
+    "aliases": [
+      "turorientering"
+    ],
+    "id": "turorientering"
   },
   {
     "name": "Stolpejakten",
     "description": "Stolpejakten is a free activity based on finding posts (stolper) placed at locations across participating municipalities. Each post has a unique code that can be logged via QR code scan or manual entry in the <a href=\"https://www.stolpejakten.no/#/about\">Stolpejakten app</a>. Downloadable maps are available from the app and website. Stolpejakten is similar to a <a href=\"#permanent-course\">permanent course</a> but is typically found in more urban areas.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Stolpejakten"
   },
   {
     "name": "clear",
     "description": "Clearing erases any previous run data stored on your timing chip before a new race. This must be done at a dedicated clear station before the start. Forgetting to clear your chip may result in incorrect timing data and disqualification.",
-    "tags": ["timing"],
+    "tags": [
+      "timing"
+    ],
     "related": [],
-    "aliases": ["clearing"]
+    "aliases": [
+      "clearing"
+    ],
+    "id": "nulle"
   },
   {
     "name": "Livelox",
     "description": "<a href=\"https://www.livelox.com/\">Livelox</a> is a platform for analysing and sharing orienteering routes. Event organisers upload the course map in advance; after the event, competitors upload GPS tracks from their watch or phone to see their route overlaid on the map and compare it with other runners. Other services such as <a href=\"http://3drerun.worldofo.com/\">3D Rerun</a> and <a href=\"http://www.opath.se/\">OPath</a> offer similar functionality, but Livelox is the most widely used.",
     "tags": [],
     "related": [],
-    "aliases": []
+    "aliases": [],
+    "id": "Livelox"
   },
   {
     "name": "score event",
     "description": "A score event (also called score orienteering or a scatter event) has a large number of controls placed close together. Runners collect controls one by one without travelling far between them. The format emphasises map reading and control identification over running fitness.",
     "tags": [],
-    "related": ["control"],
-    "aliases": ["score orienteering", "scatter event"]
+    "related": [
+      "control"
+    ],
+    "aliases": [
+      "score orienteering",
+      "scatter event"
+    ],
+    "id": "postplukk"
   },
   {
     "name": "control circle",
     "description": "The control circle is the circle printed on the orienteering map marking the exact position of a control. The circle is centred on the precise feature to be found. <i>See also <a href=\"/#control-description\">control description</a></i>.",
     "tags": [],
-    "related": ["map", "control", "control description"],
-    "aliases": []
+    "related": [
+      "map",
+      "control",
+      "control description"
+    ],
+    "aliases": [],
+    "id": "ringen"
   },
   {
     "name": "start control",
     "description": "The start control is the first control on a course. At larger events it is positioned some distance from the physical start line, with the route to it marked by streamers so runners do not need to navigate the first section. At smaller events the start and start control are usually at the same point. The start control is represented by a triangle on the map.",
     "tags": [],
-    "related": ["control"],
-    "aliases": []
+    "related": [
+      "control"
+    ],
+    "aliases": [],
+    "id": "startpost"
   },
   {
     "name": "pin punch",
     "description": "A pin punch is the traditional manual punching tool used in orienteering before electronic timing. When pressed against a punch card it leaves a unique pattern of holes, proving a competitor visited that control. Pin punches are rarely seen in modern competitions. <i>See <a href=\"/#timing\">timing</a></i>.",
-    "tags": ["timing"],
-    "related": ["timing", "control"],
-    "aliases": []
+    "tags": [
+      "timing"
+    ],
+    "related": [
+      "timing",
+      "control"
+    ],
+    "aliases": [],
+    "id": "klippetang"
   },
   {
     "name": "Sportiduino",
     "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> is an open-source electronic timing system for orienteering, offering a lower-cost alternative to <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>. It is based on the Arduino platform. Setting up a Sportiduino system requires significant time and effort as controls and a chip reader must be built from components.",
-    "tags": ["timing"],
-    "related": ["timing", "SPORTIdent", "EMIT"],
-    "aliases": []
+    "tags": [
+      "timing"
+    ],
+    "related": [
+      "timing",
+      "SPORTIdent",
+      "EMIT"
+    ],
+    "aliases": [],
+    "id": "Sportiduino"
   }
 ]

--- a/resources/orienteering_dictionary_en.json
+++ b/resources/orienteering_dictionary_en.json
@@ -1,0 +1,359 @@
+[
+  {
+    "name": "PM",
+    "description": "A PM (from Latin <i>pro memoria</i>) for an orienteering event is the event programme or race instructions — detailed information such as the exact start location, parking directions, and water station details. A PM is typically only produced for larger events.",
+    "tags": [],
+    "related": [],
+    "aliases": ["promemoria", "event programme", "race instructions"]
+  },
+  {
+    "name": "event centre",
+    "description": "The event centre (also called the arena) is the central hub of an orienteering event. Here you will find the finish, download station, officials, results boards, presentations, and often showers or refreshments. The start is often located elsewhere but is signposted from the event centre.",
+    "tags": [],
+    "related": [],
+    "aliases": ["arena"]
+  },
+  {
+    "name": "relay",
+    "description": "A relay (known in Scandinavian orienteering as <i>kavle</i> or <i>budkavle</i>) is a team format where each team member runs one or more legs of the course, handing over to the next team member at the end of their leg.",
+    "tags": ["relay"],
+    "related": [],
+    "aliases": ["kavle", "budkavle"]
+  },
+  {
+    "name": "error",
+    "description": "An error (or mistake) occurs when a competitor fails to navigate precisely to a control and loses time as a result. For elite runners, an error might mean losing 10–20 seconds; for beginners, errors can cost several minutes or more.",
+    "tags": [],
+    "related": [],
+    "aliases": ["mistake"]
+  },
+  {
+    "name": "EMIT",
+    "description": "EMIT is an electronic timing system for orienteering produced by the Norwegian company EMIT. It is the most common timing system used in Norway. Internationally, <a href=\"/#sportident\">SPORTIdent</a> is the more widely used standard. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "tags": ["timing"],
+    "related": ["SPORTIdent", "SFR"],
+    "aliases": []
+  },
+  {
+    "name": "timing",
+    "description": "Electronic timing in orienteering works via a personal timing chip registered to each competitor. When a runner arrives at a control, they punch their chip on the timing unit at that control, recording the visit. At the finish the chip is downloaded and the total time and split times between controls are displayed. The two most common systems are <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>.",
+    "tags": ["timing"],
+    "related": ["EMIT", "SPORTIdent", "SFR"],
+    "aliases": []
+  },
+  {
+    "name": "forking",
+    "description": "Forking is used to prevent competitors from <a href=\"/#following\">following</a> each other around the course. Runners in the same class receive courses that differ slightly — most controls are shared, but at certain points some runners must visit a control a short distance away from the one others in the same class visit. Runners must navigate carefully to punch the correct control; punching the wrong one results in disqualification.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "control description",
+    "description": "A control description (also called a clue sheet) is a slip attached to the map or printed directly on it. It uses standardised IOF symbols to specify exactly what feature each control is placed on — for example, that control 3 is on the west side of a large boulder.",
+    "tags": [],
+    "related": [],
+    "aliases": ["clue sheet"]
+  },
+  {
+    "name": "SPORTIdent",
+    "description": "<a href=\"https://www.sportident.com/\">SPORTIdent</a> is the most widely used electronic timing system in international orienteering. The personal chip is called an SI-card (or dibber in the UK). SPORTIdent is the standard at World Championships and the dominant system across Europe, the UK, and Australia. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "tags": ["timing"],
+    "related": ["EMIT", "SFR"],
+    "aliases": ["SI"]
+  },
+  {
+    "name": "SFR",
+    "description": "<a href=\"http://sfr-system.com/\">SFR</a> (Start Finish Result) is a Russian electronic timing system for orienteering, working on the same principle as SPORTIdent and EMIT.",
+    "tags": ["timing"],
+    "related": ["EMIT", "SPORTIdent"],
+    "aliases": []
+  },
+  {
+    "name": "Rankingløp",
+    "description": "Rankingløp is an informal training race series organised weekly by OSI Orientering and IL GeoForm in Oslo. Points are accumulated over the season to build a total ranking — hence the name. See the <a href=\"https://ilgeoform.no/rankinglop/\">Rankingløp page</a> for more information.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "Nordmarkskarusellen",
+    "description": "Nordmarkskarusellen is a series of events held in the southern part of Nordmarka, Oslo — three races in spring and four in autumn. Both beginner-friendly and challenging courses are offered. The series is a collaboration between the clubs OSI, Kjelsås, Heming, Lillomarka, Koll, and Nydalen. More information at the <a href=\"http://nordmarkskarusellen.com/\">Nordmarkskarusellen website</a>.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "Eventor",
+    "description": "<a href=\"http://eventor.orientering.no\">Eventor</a> is an online platform listing orienteering events, supporting online entry, and publishing results. Originally developed in Sweden, it is also used in Norway, Australia, and for international events. Register an account to enter events online.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "map",
+    "description": "An orienteering map shows the terrain in a simplified format and is the primary tool a runner uses to navigate between controls. It uses a rich set of symbols: contour lines show elevation, black dots indicate boulders, blue areas show water, and so on. Maps are produced at different <i><a href=\"/#scale\">scales</a></i>, typically 1:5000 for sprint orienteering and 1:10000 for forest orienteering.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "scale",
+    "description": "The scale of a map describes how much the real world has been reduced. A scale of 1:10000 means 1 cm on the map represents 10000 cm (100 metres) on the ground. Hiking maps often use scales such as 1:50000, covering a large area with limited detail. Orienteering maps are typically 1:7500 or 1:10000 for forest courses and 1:5000 or 1:4000 for sprint. A larger scale (smaller denominator) allows more terrain detail to be shown, enabling more precise navigation.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "compass",
+    "description": "A compass indicates the direction of north (and therefore south, east, and west). An orienteer uses a compass to hold a bearing towards the next <i><a href=\"/#control\">control</a></i>, or to set the map — rotating it to align with the surrounding terrain.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "control",
+    "description": "An orienteering control (also called a flag or post) consists of an orange-and-white marker flag and an attached timing unit used to record a competitor's visit to that point. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "tags": [],
+    "related": [],
+    "aliases": ["flag", "post"]
+  },
+  {
+    "name": "thumb compass",
+    "description": "A thumb compass is strapped to the thumb, allowing the runner to hold the map and compass together as one unit — the most popular style among orienteers. Traditional plate compasses are also used but are less common in competition. <i>See <a href=\"/#compass\">compass</a></i>.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "A-level",
+    "description": "A-level is the most technically demanding course difficulty in the Scandinavian grading system. All orienteering techniques are required. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
+    "tags": [],
+    "related": ["B-level", "C-level", "N-level"],
+    "aliases": []
+  },
+  {
+    "name": "B-level",
+    "description": "B-level is the second most difficult course grade in the Scandinavian grading system. B-level courses require short fine-navigation legs into the control and a good understanding of contour lines. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
+    "tags": [],
+    "related": ["A-level", "C-level", "N-level"],
+    "aliases": []
+  },
+  {
+    "name": "C-level",
+    "description": "C-level is the second easiest course grade in the Scandinavian grading system. C-level courses mostly follow <a href=\"/#handrail\">handrails</a>, but runners are expected to leave handrails at certain points. Route choice opportunities may exist. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
+    "tags": [],
+    "related": ["A-level", "B-level", "N-level"],
+    "aliases": []
+  },
+  {
+    "name": "N-level",
+    "description": "N-level is the easiest course grade in the Scandinavian grading system, designed for beginners. N-level courses follow continuous <a href=\"/#handrail\">handrails</a> such as paths, tracks, streams, and fences, with all controls visible from the handrail. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
+    "tags": [],
+    "related": ["A-level", "B-level", "C-level"],
+    "aliases": []
+  },
+  {
+    "name": "difficulty level",
+    "description": "In the Scandinavian grading system, courses are divided into four difficulty levels: <a href=\"/#a-level\">A</a>, <a href=\"/#b-level\">B</a>, <a href=\"/#c-level\">C</a>, and <a href=\"/#n-level\">N</a>, where A is the hardest and N is a beginner course. Other countries use colour-coded systems — the UK uses White, Yellow, Orange, Light Green, Green, Blue, and Brown; Australia uses White, Yellow, Orange, Red, and Blue.",
+    "tags": [],
+    "related": ["A-level", "B-level", "C-level", "N-level"],
+    "aliases": []
+  },
+  {
+    "name": "following",
+    "description": "Following means trailing another orienteer and navigating using their decisions rather than your own map reading. This is considered poor sportsmanship in orienteering.",
+    "tags": [],
+    "related": [],
+    "aliases": ["tailing", "shadowing"]
+  },
+  {
+    "name": "W",
+    "description": "W stands for Women, used in English-language class designations (e.g. W21E for elite women aged 21 and over). In Scandinavian events you will see D instead, from the Swedish/Norwegian word <i>Dame/Damer</i>.",
+    "tags": [],
+    "related": ["M"],
+    "aliases": ["D"]
+  },
+  {
+    "name": "M",
+    "description": "M stands for Men, used in English-language class designations (e.g. M21E for elite men aged 21 and over). In Scandinavian events you will see H instead, from the Swedish/Norwegian word <i>Herre/Herrer</i>.",
+    "tags": [],
+    "related": ["W"],
+    "aliases": ["H"]
+  },
+  {
+    "name": "O",
+    "description": "Orienteers love the letter O and use it wherever possible: o-shoes (<a href=\"/#orienteering-shoes\">orienteering shoes</a>), o-training (orienteering training), o-suit, o-sport, and so on. It is shorthand for orienteering and is widely used in English-speaking clubs as well as Scandinavian ones.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "orienteering shoes",
+    "description": "Orienteering shoes have aggressive lugged soles and are often fitted with metal spikes for the best possible grip on slippery terrain, wet roots, and icy ground.",
+    "tags": [],
+    "related": [],
+    "aliases": ["o-shoes"]
+  },
+  {
+    "name": "handrail",
+    "description": "A handrail is a linear feature that is easy to identify on the map and easy to follow in the terrain — examples include streams, paths, field edges, and fences. A handrail guides you safely from one place to another and can also act as a catching feature: a line you will inevitably cross if you overshoot your target.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "georeferencing",
+    "description": "Georeferencing an orienteering map means aligning it with a standard coordinate system (such as WGS84). This allows GPS tracks recorded on a watch or phone to be overlaid accurately on the map for post-race route analysis. Without georeferencing, a GPS track and the map cannot be reliably aligned.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "Kjempesprekken",
+    "description": "Kjempesprekken is the highlight of OSI Orientering's year — a long-standing traditional event starting near the KSI hut in Nordmarka, Oslo. Courses of 18 km, 12 km, and 6 km wind through beautiful Nordmarka terrain. A club banquet follows the race at the KSI hut.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "Tiomila",
+    "description": "One of Scandinavia's biggest and most prestigious orienteering relays, held in Sweden each spring. Women compete during the day (5 legs) and men run through the night (10 legs).",
+    "tags": ["relay"],
+    "related": ["Jukola", "Night Hawk"],
+    "aliases": []
+  },
+  {
+    "name": "Jukola",
+    "description": "Jukola is one of the world's largest orienteering relays, with around 15 000 competitors. Held in Finland each June, women race during the day (4 legs) and men race through the night (7 legs).",
+    "tags": ["relay"],
+    "related": ["Tiomila", "Night Hawk"],
+    "aliases": []
+  },
+  {
+    "name": "Night Hawk",
+    "description": "Night Hawk is Norway's equivalent of Tiomila and Jukola — a major orienteering relay held in August. Women run 6 legs and men run 8 legs, with roughly half of each relay taking place in darkness and the other half in daylight.",
+    "tags": ["relay"],
+    "related": ["Tiomila", "Jukola"],
+    "aliases": []
+  },
+  {
+    "name": "night orienteering",
+    "description": "Orienteering in the dark. Many orienteers find night orienteering more absorbing than daylight running — navigating by headtorch demands much greater concentration and map contact. Knowing your precise position on the map matters even more when the visible world is restricted to the beam of your torch. Spotting the reflective marker of a control in the darkness gives a great sense of achievement.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "retire",
+    "description": "If you are injured or hopelessly lost, you may retire from the race. Find the quickest safe route back to the <a href=\"/#event-centre\">event centre</a>. It is essential to report to the finish or download station even when retiring, so officials know you are safe and do not launch a search. Runners who retire are recorded as DNF (Did Not Finish) on the results.",
+    "tags": [],
+    "related": [],
+    "aliases": ["DNF"]
+  },
+  {
+    "name": "open entry",
+    "description": "Open entry (or direct start) classes are courses that can be entered on the day at the event without advance registration. There is typically no age or gender split in these classes. They are ideal for newcomers or anyone who missed the entry deadline.",
+    "tags": [],
+    "related": [],
+    "aliases": ["direct start", "direct entry"]
+  },
+  {
+    "name": "trail orienteering",
+    "description": "Trail orienteering (pre-O) is the IOF-recognised discipline designed to be accessible to both able-bodied and mobility-impaired participants. Courses follow paths and tracks accessible by wheelchair. The challenge is map-reading accuracy rather than running speed — at each control site, several markers are placed and the competitor must identify which one (if any) matches the map and <a href=\"/#control-description\">control description</a>. Some controls have a single marker where the task is to decide which of several control descriptions is correct.",
+    "tags": [],
+    "related": [],
+    "aliases": ["pre-O", "precision orienteering"]
+  },
+  {
+    "name": "children's courses",
+    "description": "Children's courses (known in Norway as <i>småtroll</i>, meaning 'little trolls') are designed for the very youngest participants. They are marked routes featuring fun, engaging controls rather than standard orienteering flags, with an emphasis on enjoyment and adventure over precise map reading. All finishers typically receive a prize.",
+    "tags": [],
+    "related": [],
+    "aliases": ["småtroll"]
+  },
+  {
+    "name": "contour interval",
+    "description": "The contour interval is the difference in elevation between two adjacent contour lines (the brown lines on an orienteering map). A smaller contour interval allows more elevation detail to be shown. On most orienteering maps the contour interval is 5 metres. See <a href=\"/#index-contour\">index contour</a>.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "index contour",
+    "description": "Every fifth contour line on a map is drawn thicker — this is an index contour. Index contours make it quick and easy to calculate larger height differences. With a <a href=\"/#contour-interval\">contour interval</a> of 5 metres, each index contour represents 25 metres of elevation. Three index contours between you and your next control therefore means 75 metres of climbing.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "OSI",
+    "description": "OSI stands for Oslostudentenes Idrettsklubb (Oslo Students' Sports Club). The orienteering branch, OSI Orientering, organises events and training in and around Oslo.",
+    "tags": [],
+    "related": [],
+    "aliases": ["Oslostudentenes Idrettsklubb", "Oslostudentenes IK"]
+  },
+  {
+    "name": "permanent course",
+    "description": "A permanent course is an orienteering course you can complete at your own pace, whenever you like throughout the season. You purchase or download a map with the controls marked; the controls remain in the forest for months. Controls are typically coded and visits can be logged on platforms such as <a href=\"http://turorientering.no/\">turorientering.no</a> to track your progress.",
+    "tags": [],
+    "related": [],
+    "aliases": ["turorientering"]
+  },
+  {
+    "name": "Stolpejakten",
+    "description": "Stolpejakten is a free activity based on finding posts (stolper) placed at locations across participating municipalities. Each post has a unique code that can be logged via QR code scan or manual entry in the <a href=\"https://www.stolpejakten.no/#/about\">Stolpejakten app</a>. Downloadable maps are available from the app and website. Stolpejakten is similar to a <a href=\"#permanent-course\">permanent course</a> but is typically found in more urban areas.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "clear",
+    "description": "Clearing erases any previous run data stored on your timing chip before a new race. This must be done at a dedicated clear station before the start. Forgetting to clear your chip may result in incorrect timing data and disqualification.",
+    "tags": ["timing"],
+    "related": [],
+    "aliases": ["clearing"]
+  },
+  {
+    "name": "Livelox",
+    "description": "<a href=\"https://www.livelox.com/\">Livelox</a> is a platform for analysing and sharing orienteering routes. Event organisers upload the course map in advance; after the event, competitors upload GPS tracks from their watch or phone to see their route overlaid on the map and compare it with other runners. Other services such as <a href=\"http://3drerun.worldofo.com/\">3D Rerun</a> and <a href=\"http://www.opath.se/\">OPath</a> offer similar functionality, but Livelox is the most widely used.",
+    "tags": [],
+    "related": [],
+    "aliases": []
+  },
+  {
+    "name": "score event",
+    "description": "A score event (also called score orienteering or a scatter event) has a large number of controls placed close together. Runners collect controls one by one without travelling far between them. The format emphasises map reading and control identification over running fitness.",
+    "tags": [],
+    "related": ["control"],
+    "aliases": ["score orienteering", "scatter event"]
+  },
+  {
+    "name": "control circle",
+    "description": "The control circle is the circle printed on the orienteering map marking the exact position of a control. The circle is centred on the precise feature to be found. <i>See also <a href=\"/#control-description\">control description</a></i>.",
+    "tags": [],
+    "related": ["map", "control", "control description"],
+    "aliases": []
+  },
+  {
+    "name": "start control",
+    "description": "The start control is the first control on a course. At larger events it is positioned some distance from the physical start line, with the route to it marked by streamers so runners do not need to navigate the first section. At smaller events the start and start control are usually at the same point. The start control is represented by a triangle on the map.",
+    "tags": [],
+    "related": ["control"],
+    "aliases": []
+  },
+  {
+    "name": "pin punch",
+    "description": "A pin punch is the traditional manual punching tool used in orienteering before electronic timing. When pressed against a punch card it leaves a unique pattern of holes, proving a competitor visited that control. Pin punches are rarely seen in modern competitions. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "tags": ["timing"],
+    "related": ["timing", "control"],
+    "aliases": []
+  },
+  {
+    "name": "Sportiduino",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> is an open-source electronic timing system for orienteering, offering a lower-cost alternative to <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>. It is based on the Arduino platform. Setting up a Sportiduino system requires significant time and effort as controls and a chip reader must be built from components.",
+    "tags": ["timing"],
+    "related": ["timing", "SPORTIdent", "EMIT"],
+    "aliases": []
+  }
+]

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -31,6 +31,7 @@
       {%- endfor %}
     </nav>
     <button class="theme-toggle" id="theme-toggle" aria-label="{{ lang.darkMode }}">🌙</button>
+    <button class="translations-toggle" id="translations-toggle" aria-pressed="false">{{ lang.showTranslations }}</button>
   </header>
 
   <main class="main">
@@ -64,6 +65,22 @@
       root.setAttribute('data-theme', next);
       localStorage.setItem('theme', next);
       updateBtn(next);
+    });
+
+    var transBtn = document.getElementById('translations-toggle');
+    var body = document.body;
+    function updateTransBtn(on) {
+      transBtn.textContent = on ? '{{ lang.hideTranslations }}' : '{{ lang.showTranslations }}';
+      transBtn.setAttribute('aria-pressed', on ? 'true' : 'false');
+    }
+    var transOn = localStorage.getItem('show-translations') === 'true';
+    if (transOn) body.classList.add('show-translations');
+    updateTransBtn(transOn);
+    transBtn.addEventListener('click', function() {
+      transOn = !transOn;
+      body.classList.toggle('show-translations', transOn);
+      localStorage.setItem('show-translations', transOn);
+      updateTransBtn(transOn);
     });
   </script>
   <script defer src="/_vercel/insights/script.js"></script>

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -30,8 +30,10 @@
         <a href="{{ l.path }}"{% if l.code == lang.langCode %} class="active" aria-current="page"{% endif %}>{{ l.name }}</a>
       {%- endfor %}
     </nav>
-    <button class="theme-toggle" id="theme-toggle" aria-label="{{ lang.darkMode }}">🌙</button>
-    <button class="translations-toggle" id="translations-toggle" aria-pressed="false">{{ lang.showTranslations }}</button>
+    <div class="header-actions">
+      <button class="translations-toggle" id="translations-toggle" aria-pressed="false">{{ lang.showTranslations }}</button>
+      <button class="theme-toggle" id="theme-toggle" aria-label="{{ lang.darkMode }}">🌙</button>
+    </div>
   </header>
 
   <main class="main">

--- a/src/_includes/dictionary.njk
+++ b/src/_includes/dictionary.njk
@@ -6,5 +6,19 @@
     <dt class="o-term" id="{{ alias | slugify }}">{{ alias }}</dt>
     {%- endfor %}
     <dd class="o-description">{{ entry.description | safe }}</dd>
+    {%- if entry.id %}
+      {%- set crossLinks = [] %}
+      {%- for locale, map in dictionaryMaps %}
+        {%- if locale != langCode %}
+          {%- set other = map[entry.id] %}
+          {%- if other %}
+            {%- set crossLinks = (crossLinks.push("<a href='" + langPaths[locale] + "#" + (other.name | slugify) + "'>" + other.name + "</a> (" + translations[locale].langName + ")"), crossLinks) %}
+          {%- endif %}
+        {%- endif %}
+      {%- endfor %}
+      {%- if crossLinks.length %}
+    <dd class="o-also-in">{{ crossLinks | join(" &middot; ") | safe }}</dd>
+      {%- endif %}
+    {%- endif %}
   {%- endfor %}
 </dl>

--- a/src/_includes/dictionary.njk
+++ b/src/_includes/dictionary.njk
@@ -1,5 +1,6 @@
 <dl>
-  {%- for entry in dictionary %}
+  {%- set entries = dictionaries[langCode] or dictionaries['no'] %}
+  {%- for entry in entries %}
     <dt class="o-term" id="{{ entry.name | slugify }}">{{ entry.name }}</dt>
     {%- for alias in entry.aliases %}
     <dt class="o-term" id="{{ alias | slugify }}">{{ alias }}</dt>

--- a/src/style.css
+++ b/src/style.css
@@ -82,7 +82,6 @@ a:hover, a:focus { text-decoration: underline; }
   font-size: 1.2rem;
   padding: 0.2rem 0.5rem;
   line-height: 1.5;
-  flex-shrink: 0;
 }
 
 .main {
@@ -142,6 +141,13 @@ body.show-translations .o-description {
   margin-bottom: 0;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
 .translations-toggle {
   background: none;
   border: 1px solid var(--border);
@@ -150,7 +156,6 @@ body.show-translations .o-description {
   font-size: 0.8rem;
   padding: 0.2rem 0.5rem;
   line-height: 1.5;
-  flex-shrink: 0;
   color: var(--text);
   opacity: 0.7;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -117,8 +117,17 @@ dl { margin: 0; }
 .o-description {
   margin-left: 0;
   padding-bottom: 0.5rem;
+  margin-bottom: 0;
+}
+
+.o-also-in {
+  margin-left: 0;
+  margin-top: 0.15rem;
+  padding-bottom: 0.5rem;
   border-bottom: 1px solid var(--border);
   margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-muted, color-mix(in srgb, var(--text) 60%, transparent));
 }
 
 .footer {

--- a/src/style.css
+++ b/src/style.css
@@ -117,10 +117,12 @@ dl { margin: 0; }
 .o-description {
   margin-left: 0;
   padding-bottom: 0.5rem;
-  margin-bottom: 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 0.5rem;
 }
 
 .o-also-in {
+  display: none;
   margin-left: 0;
   margin-top: 0.15rem;
   padding-bottom: 0.5rem;
@@ -128,6 +130,33 @@ dl { margin: 0; }
   margin-bottom: 0.5rem;
   font-size: 0.85rem;
   color: var(--text-muted, color-mix(in srgb, var(--text) 60%, transparent));
+}
+
+body.show-translations .o-also-in {
+  display: block;
+}
+
+body.show-translations .o-description {
+  border-bottom: none;
+  padding-bottom: 0;
+  margin-bottom: 0;
+}
+
+.translations-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  line-height: 1.5;
+  flex-shrink: 0;
+  color: var(--text);
+  opacity: 0.7;
+}
+
+.translations-toggle:hover {
+  opacity: 1;
 }
 
 .footer {


### PR DESCRIPTION
Translates all 51 terms for English-speaking orienteers (UK, Australia, Canada).

- New file `resources/orienteering_dictionary_en.json` with English translations
- Updated `eleventy.config.js` to expose all dictionaries keyed by locale via `dictionaries` global
- Updated `dictionary.njk` to pick the correct dictionary per locale, falling back to Norwegian for untranslated languages
- Standard English orienteering terminology throughout (IOF/British Orienteering/Orienteering Australia)
- Internal href links updated to use English slugified anchors

Partially closes #97 (English only).