### PR TITLE
fix: apply word edits from issue #100 across all languages

### DIFF
--- a/resources/orienteering_dictionary.json
+++ b/resources/orienteering_dictionary.json
@@ -350,7 +350,7 @@
   },
   {
     "name": "direkteklasser",
-    "description": "Direkteklasser er klasser der man kan melde seg på ved oppmøte på konkurransedagen, man behøver altså ikke å forhåndspåmelde seg. Det er vanligvis ikke alders- eller kjønnsinndeling i disse klassene. Direktepåmelding er praktisk for etternølere og passer spesielt godt for familier med barn, der foreldre trenger fleksibilitet rundt oppmøtetid.",
+    "description": "Direkteklasser er klasser der man kan melde seg på ved oppmøte på konkurransedagen, man behøver altså ikke å forhåndspåmelde seg. Det er vanligvis ikke alders- eller kjønnsinndeling i disse klassene. Direktepåmelding er praktisk for etternølere og passer spesielt godt for barnefamilier, der foreldre trenger fleksibilitet rundt oppmøtetid.",
     "tags": [],
     "related": [],
     "aliases": [],

--- a/resources/orienteering_dictionary.json
+++ b/resources/orienteering_dictionary.json
@@ -510,7 +510,7 @@
   },
   {
     "name": "emiTag",
-    "description": "emiTag er EMITs kontaktløse brikke – tilsvarende <a href=\"/#siac\">SIAC</a> for SPORTIdent. Brikken registrerer automatisk når den føres nær kontrollenheten uten å måtte stikkes inn. Brukes på løp som benytter EMIT-systemet. <i>Se <a href=\"/#tidtaking\">tidtaking</a></i>.",
+    "description": "emiTag er EMITs kontaktløse brikke – tilsvarende <a href=\"/#siac\">SIAC</a> for SPORTIdent. Brikken registrerer automatisk når den føres nær kontrollenheten uten å måtte stemples på Brukes på løp som benytter EMIT-systemet. <i>Se <a href=\"/#tidtaking\">tidtaking</a></i>.",
     "tags": [
       "tidtaking"
     ],

--- a/resources/orienteering_dictionary.json
+++ b/resources/orienteering_dictionary.json
@@ -39,13 +39,14 @@
   },
   {
     "name": "EMIT",
-    "description": "I norsk orientering bruker man et eletronisk tidtakersystem som produseres av det norske firmaet EMIT, <i>se <a href=\"/#tidtaking\">tidtaking</a></i>. I Sverige brukes <a href=\"/#SPORTIdent\">SportIdent</a>.",
+    "description": "EMIT er et elektronisk tidtakersystem for orientering produsert av det norske firmaet EMIT. Det er det dominerende systemet i norsk og finsk orientering. I Sverige og internasjonalt er <a href=\"/#sportident\">SPORTIdent</a> vanligere. <i>Se <a href=\"/#tidtaking\">tidtaking</a></i>.",
     "tags": [
       "tidtaking"
     ],
     "related": [
       "SPORTIdent",
-      "SFR"
+      "SFR",
+      "emiTag"
     ],
     "aliases": [],
     "id": "EMIT"
@@ -88,7 +89,8 @@
     ],
     "related": [
       "EMIT",
-      "SFR"
+      "SFR",
+      "SIAC"
     ],
     "aliases": [],
     "id": "SPORTIdent"
@@ -113,14 +115,6 @@
     "related": [],
     "aliases": [],
     "id": "Rankingløp"
-  },
-  {
-    "name": "Nordmarkskarusellen",
-    "description": "Nordmarkskarusellen er en samling løp rundt om i sør-enden av Nordmarka. Tre løp på våren og fire løp på høsten. Det tilbys nybegynnervennlige løyper og krevende løyper. Løpene er et samarbeid mellom klubbene OSI, Kjelsås, Heming, Lillomarka, Koll og Nydalen. Les mer på Nordmarkskarusellen sin <a href=\"http://nordmarkskarusellen.com/\">hjemmeside</a>.",
-    "tags": [],
-    "related": [],
-    "aliases": [],
-    "id": "Nordmarkskarusellen"
   },
   {
     "name": "Eventor",
@@ -356,7 +350,7 @@
   },
   {
     "name": "direkteklasser",
-    "description": "Direkteklasser er klasser der man kan melde seg på ved oppmøte på konkurransedagen, man behøver altså ikke å forhåndspåmelde seg. Det er vanligvis ikke alders eller kjønnsinndeling i disse klassene. Direktepåmelding er praktisk for etternølere.",
+    "description": "Direkteklasser er klasser der man kan melde seg på ved oppmøte på konkurransedagen, man behøver altså ikke å forhåndspåmelde seg. Det er vanligvis ikke alders- eller kjønnsinndeling i disse klassene. Direktepåmelding er praktisk for etternølere og passer spesielt godt for familier med barn, der foreldre trenger fleksibilitet rundt oppmøtetid.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -398,7 +392,7 @@
   },
   {
     "name": "OSI",
-    "description": "Oslostudentenes Idrettsklubb. Også forkortet Oslostudentenes IK",
+    "description": "Oslostudentenes Idrettsklubb, også forkortet Oslostudentenes IK. OSI Orientering er klubben som har laget denne ordlisten.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -485,7 +479,7 @@
   },
   {
     "name": "Sportiduino",
-    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> er et åpen kildekode-system for elektronisk tidtaking i orientering, og er et rimeligere alternativ til <a href=\"/#SPORTIdent\">SPORTIdent</a> og <a href=\"/#EMIT\">EMIT</a>. Systemet er basert på Arduino-plattformen, men krever betydelig tid og innsats å sette opp da man selv må bygge poster og brikkeleser.",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> er et åpen kildekode-system for elektronisk tidtaking i orientering, og er et rimeligere alternativ til <a href=\"/#sportident\">SPORTIdent</a> og <a href=\"/#emit\">EMIT</a>. Systemet er basert på Arduino-plattformen, men krever betydelig tid og innsats å sette opp da man selv må bygge poster og brikkeleser. Et annet åpen kildekode-alternativ er <a href=\"https://github.com/oribos-ts\">OribosTS</a>.",
     "tags": [
       "tidtaking"
     ],
@@ -496,5 +490,52 @@
     ],
     "aliases": [],
     "id": "Sportiduino"
+  },
+  {
+    "name": "SIAC",
+    "description": "SIAC (SportIdent Air+ Card) er SPORTIdents kontaktløse brikke. I motsetning til en vanlig SI-brikke trenger man ikke å stikke brikken ned i stemplingsboksen – brikken registrerer automatisk når den holdes nær kontrollenheten, og piper og blinker for å bekrefte godkjent stempling. SIAC krever kontroller utstyrt med Air+-enheter. <i>Se <a href=\"/#tidtaking\">tidtaking</a></i>.",
+    "tags": [
+      "tidtaking"
+    ],
+    "related": [
+      "SPORTIdent",
+      "emiTag",
+      "tidtaking"
+    ],
+    "aliases": [
+      "SportIdent Air+ Card",
+      "SI Air+"
+    ],
+    "id": "SIAC"
+  },
+  {
+    "name": "emiTag",
+    "description": "emiTag er EMITs kontaktløse brikke – tilsvarende <a href=\"/#siac\">SIAC</a> for SPORTIdent. Brikken registrerer automatisk når den føres nær kontrollenheten uten å måtte stikkes inn. Brukes på løp som benytter EMIT-systemet. <i>Se <a href=\"/#tidtaking\">tidtaking</a></i>.",
+    "tags": [
+      "tidtaking"
+    ],
+    "related": [
+      "EMIT",
+      "SIAC",
+      "SPORTIdent",
+      "tidtaking"
+    ],
+    "aliases": [],
+    "id": "emiTag"
+  },
+  {
+    "name": "Huichang",
+    "description": "Huichang er et kinesisk elektronisk tidtakersystem for orientering, produsert av Beijing Huichang Sports Technology. Det er det dominerende tidtakersystemet i kinesisk orientering og er utbredt i mange asiatiske land. Systemet fungerer etter samme prinsipp som <a href=\"/#sportident\">SPORTIdent</a> og <a href=\"/#emit\">EMIT</a>. <i>Se <a href=\"/#tidtaking\">tidtaking</a></i>.",
+    "tags": [
+      "tidtaking"
+    ],
+    "related": [
+      "SPORTIdent",
+      "EMIT",
+      "SFR",
+      "tidtaking"
+    ],
+    "aliases": [],
+    "id": "Huichang"
   }
 ]

--- a/resources/orienteering_dictionary_en.json
+++ b/resources/orienteering_dictionary_en.json
@@ -46,13 +46,14 @@
   },
   {
     "name": "EMIT",
-    "description": "EMIT is an electronic timing system for orienteering produced by the Norwegian company EMIT. It is the most common timing system used in Norway. Internationally, <a href=\"/#sportident\">SPORTIdent</a> is the more widely used standard. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "description": "EMIT is an electronic timing system for orienteering produced by the Norwegian company EMIT. It is the dominant timing system in Norwegian and Finnish orienteering. Internationally, <a href=\"/#sportident\">SPORTIdent</a> is the more widely used standard. <i>See <a href=\"/#timing\">timing</a></i>.",
     "tags": [
       "timing"
     ],
     "related": [
       "SPORTIdent",
-      "SFR"
+      "SFR",
+      "emiTag"
     ],
     "aliases": [],
     "id": "EMIT"
@@ -97,7 +98,8 @@
     ],
     "related": [
       "EMIT",
-      "SFR"
+      "SFR",
+      "SIAC"
     ],
     "aliases": [
       "SI"
@@ -124,14 +126,6 @@
     "related": [],
     "aliases": [],
     "id": "Rankingløp"
-  },
-  {
-    "name": "Nordmarkskarusellen",
-    "description": "Nordmarkskarusellen is a series of events held in the southern part of Nordmarka, Oslo — three races in spring and four in autumn. Both beginner-friendly and challenging courses are offered. The series is a collaboration between the clubs OSI, Kjelsås, Heming, Lillomarka, Koll, and Nydalen. More information at the <a href=\"http://nordmarkskarusellen.com/\">Nordmarkskarusellen website</a>.",
-    "tags": [],
-    "related": [],
-    "aliases": [],
-    "id": "Nordmarkskarusellen"
   },
   {
     "name": "Eventor",
@@ -381,7 +375,7 @@
   },
   {
     "name": "open entry",
-    "description": "Open entry (or direct start) classes are courses that can be entered on the day at the event without advance registration. There is typically no age or gender split in these classes. They are ideal for newcomers or anyone who missed the entry deadline.",
+    "description": "Open entry (or direct start) classes are courses that can be entered on the day at the event without advance registration. There is typically no age or gender split in these classes. They are ideal for newcomers, anyone who missed the entry deadline, and families with children where parents need flexibility around arrival times.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -429,7 +423,7 @@
   },
   {
     "name": "OSI",
-    "description": "OSI stands for Oslostudentenes Idrettsklubb (Oslo Students' Sports Club). The orienteering branch, OSI Orientering, organises events and training in and around Oslo.",
+    "description": "OSI stands for Oslostudentenes Idrettsklubb (Oslo Students' Sports Club). The orienteering branch, OSI Orientering, organises events and training in and around Oslo. This glossary was created by OSI Orientering.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -526,7 +520,7 @@
   },
   {
     "name": "Sportiduino",
-    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> is an open-source electronic timing system for orienteering, offering a lower-cost alternative to <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>. It is based on the Arduino platform. Setting up a Sportiduino system requires significant time and effort as controls and a chip reader must be built from components.",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> is an open-source electronic timing system for orienteering, offering a lower-cost alternative to <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>. It is based on the Arduino platform; setting it up requires significant time and effort as controls and a chip reader must be built from components. Another open-source timing alternative is <a href=\"https://github.com/oribos-ts\">OribosTS</a>.",
     "tags": [
       "timing"
     ],
@@ -537,5 +531,52 @@
     ],
     "aliases": [],
     "id": "Sportiduino"
+  },
+  {
+    "name": "SIAC",
+    "description": "SIAC (SPORTIdent Air+ Card) is SPORTIdent's contactless timing chip. Unlike a standard SI-card, the SIAC does not need to be physically inserted into the control unit — it registers automatically when held close enough, then beeps and flashes to confirm a valid punch. SIAC requires controls equipped with Air+ units. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "tags": [
+      "timing"
+    ],
+    "related": [
+      "SPORTIdent",
+      "emiTag",
+      "timing"
+    ],
+    "aliases": [
+      "SPORTIdent Air+ Card",
+      "SI Air+"
+    ],
+    "id": "SIAC"
+  },
+  {
+    "name": "emiTag",
+    "description": "The emiTag is EMIT's contactless timing chip — the equivalent of <a href=\"/#siac\">SIAC</a> for the SPORTIdent system. It registers automatically as it passes close to the control unit without needing physical insertion. Used at events running the EMIT system. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "tags": [
+      "timing"
+    ],
+    "related": [
+      "EMIT",
+      "SIAC",
+      "SPORTIdent",
+      "timing"
+    ],
+    "aliases": [],
+    "id": "emiTag"
+  },
+  {
+    "name": "Huichang",
+    "description": "Huichang is a Chinese electronic timing system for orienteering, produced by Beijing Huichang Sports Technology. It is the dominant timing system in Chinese orienteering and is widely used across Asia. It operates on the same principles as <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "tags": [
+      "timing"
+    ],
+    "related": [
+      "SPORTIdent",
+      "EMIT",
+      "SFR",
+      "timing"
+    ],
+    "aliases": [],
+    "id": "Huichang"
   }
 ]

--- a/resources/orienteering_dictionary_sv.json
+++ b/resources/orienteering_dictionary_sv.json
@@ -45,13 +45,14 @@
   },
   {
     "name": "EMIT",
-    "description": "EMIT är ett elektroniskt tidtagningssystem för orientering tillverkat av det norska företaget EMIT. Det är det vanligaste tidtagningssystemet i norsk orientering. I Sverige används <a href=\"/#sportident\">SPORTIdent</a> som standard. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "description": "EMIT är ett elektroniskt tidtagningssystem för orientering tillverkat av det norska företaget EMIT. Det är det dominerande systemet i norsk och finsk orientering. I Sverige och internationellt används <a href=\"/#sportident\">SPORTIdent</a> som standard. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
     "tags": [
       "tidtagning"
     ],
     "related": [
       "SPORTIdent",
-      "SFR"
+      "SFR",
+      "emiTag"
     ],
     "aliases": [],
     "id": "EMIT"
@@ -96,7 +97,8 @@
     ],
     "related": [
       "EMIT",
-      "SFR"
+      "SFR",
+      "SIAC"
     ],
     "aliases": [
       "SI"
@@ -123,14 +125,6 @@
     "related": [],
     "aliases": [],
     "id": "Rankingløp"
-  },
-  {
-    "name": "Nordmarkskarusellen",
-    "description": "Nordmarkskarusellen är en tävlingsserie i södra delen av Nordmarka i Oslo — tre lopp på våren och fyra på hösten. Både nybörjarvänliga och krävande banor erbjuds. Serien är ett samarbete mellan klubbarna OSI, Kjelsås, Heming, Lillomarka, Koll och Nydalen. Mer information finns på <a href=\"https://nordmarkskarusellen.no/\">nordmarkskarusellen.no</a>.",
-    "tags": [],
-    "related": [],
-    "aliases": [],
-    "id": "Nordmarkskarusellen"
   },
   {
     "name": "Eventor",
@@ -377,7 +371,7 @@
   },
   {
     "name": "direktklasser",
-    "description": "Direktklasser är klasser man kan anmäla sig till på tävlingsdagen utan förhandsanmälan. Det finns vanligtvis ingen ålders- eller könsindelning i dessa klasser. Direktklasser passar utmärkt för nybörjare eller den som missat anmälningsdeadline.",
+    "description": "Direktklasser är klasser man kan anmäla sig till på tävlingsdagen utan förhandsanmälan. Det finns vanligtvis ingen ålders- eller könsindelning i dessa klasser. Direktklasser passar utmärkt för nybörjare, den som missat anmälningsdeadline och familjer med barn där föräldrar behöver flexibilitet kring ankomsttider.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -422,7 +416,7 @@
   },
   {
     "name": "OSI",
-    "description": "Oslostudentenes Idrettsklubb. Även förkortat Oslostudentenes IK. Orienteringssektionen, OSI Orientering, arrangerar tävlingar och träning i och runt Oslo.",
+    "description": "Oslostudentenes Idrettsklubb, även förkortat Oslostudentenes IK. Orienteringssektionen OSI Orientering arrangerar tävlingar och träning i och runt Oslo. Denna ordlista skapades av OSI Orientering.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -521,7 +515,7 @@
   },
   {
     "name": "Sportiduino",
-    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> är ett system med öppen källkod för elektronisk tidtagning i orientering och är ett prisvärt alternativ till <a href=\"/#sportident\">SPORTIdent</a> och <a href=\"/#emit\">EMIT</a>. Det är baserat på Arduino-plattformen och kräver inga licenser.",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> är ett system med öppen källkod för elektronisk tidtagning i orientering och ett prisvärt alternativ till <a href=\"/#sportident\">SPORTIdent</a> och <a href=\"/#emit\">EMIT</a>. Det är baserat på Arduino-plattformen och kräver inga licenser, men ett visst mått av teknisk kompetens för att bygga kontroller och bricklösare. Ett annat alternativ med öppen källkod är <a href=\"https://github.com/oribos-ts\">OribosTS</a>.",
     "tags": [
       "tidtagning"
     ],
@@ -532,5 +526,52 @@
     ],
     "aliases": [],
     "id": "Sportiduino"
+  },
+  {
+    "name": "SIAC",
+    "description": "SIAC (SPORTIdent Air+ Card) är SPORTIdents kontaktlösa bricka. Till skillnad från en vanlig SI-bricka behöver man inte trycka ner brickan i stämplingslådan – den registrerar automatiskt när den hålls nära kontrollenheten och piper och blinkar för att bekräfta giltig stämpling. SIAC kräver kontroller utrustade med Air+-enheter. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "tags": [
+      "tidtagning"
+    ],
+    "related": [
+      "SPORTIdent",
+      "emiTag",
+      "tidtagning"
+    ],
+    "aliases": [
+      "SPORTIdent Air+ Card",
+      "SI Air+"
+    ],
+    "id": "SIAC"
+  },
+  {
+    "name": "emiTag",
+    "description": "emiTag är EMITs kontaktlösa bricka – motsvarigheten till <a href=\"/#siac\">SIAC</a> för SPORTIdent. Den registrerar automatiskt när den förs nära kontrollenheten utan att behöva tryckas in. Används på tävlingar med EMIT-systemet. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "tags": [
+      "tidtagning"
+    ],
+    "related": [
+      "EMIT",
+      "SIAC",
+      "SPORTIdent",
+      "tidtagning"
+    ],
+    "aliases": [],
+    "id": "emiTag"
+  },
+  {
+    "name": "Huichang",
+    "description": "Huichang är ett kinesiskt elektroniskt tidtagningssystem för orientering, tillverkat av Beijing Huichang Sports Technology. Det är det dominerande tidtagningssystemet i kinesisk orientering och används brett i Asien. Systemet fungerar enligt samma princip som <a href=\"/#sportident\">SPORTIdent</a> och <a href=\"/#emit\">EMIT</a>. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "tags": [
+      "tidtagning"
+    ],
+    "related": [
+      "SPORTIdent",
+      "EMIT",
+      "SFR",
+      "tidtagning"
+    ],
+    "aliases": [],
+    "id": "Huichang"
   }
 ]

--- a/resources/orienteering_dictionary_sv.json
+++ b/resources/orienteering_dictionary_sv.json
@@ -371,7 +371,7 @@
   },
   {
     "name": "direktklasser",
-    "description": "Direktklasser är klasser man kan anmäla sig till på tävlingsdagen utan förhandsanmälan. Det finns vanligtvis ingen ålders- eller könsindelning i dessa klasser. Direktklasser passar utmärkt för nybörjare, den som missat anmälningsdeadline och familjer med barn där föräldrar behöver flexibilitet kring ankomsttider.",
+    "description": "Direktklasser är klasser man kan anmäla sig till på tävlingsdagen utan förhandsanmälan. Det finns vanligtvis ingen ålders- eller könsindelning i dessa klasser. Direktklasser passar utmärkt för nybörjare, den som missat anmälningsdeadline och barnfamiljer där föräldrar behöver flexibilitet kring ankomsttider.",
     "tags": [],
     "related": [],
     "aliases": [],


### PR DESCRIPTION
Applies all edits from #100 to Norwegian, English, and Swedish dictionaries.

**Removals**
- Nordmarkskarusellen removed (too locally specific)

**Updated entries**
- **OSI**: added note that this club created the dictionary
- **EMIT**: noted as dominant in both Norway *and* Finland
- **direkteklasser / open entry / direktklasser**: added mention of families with children needing start-time flexibility
- **Sportiduino**: mentions OribosTS as another open-source timing alternative

**New entries** (all three languages)
- **SIAC** — SPORTIdent Air+ Card; contactless chip that punches without physical insertion, beeps/flashes on valid punch
- **emiTag** — EMIT's equivalent contactless chip
- **Huichang** — Chinese timing system from Beijing Huichang Sports Technology; dominant in Chinese and Asian orienteering

Closes #100