### PR TITLE
fix: update Night Hawk to reflect discontinuation

### DIFF
--- a/resources/orienteering_dictionary.json
+++ b/resources/orienteering_dictionary.json
@@ -321,7 +321,7 @@
   },
   {
     "name": "Night Hawk",
-    "description": "I Sverige har man Tiomila, i Finland har man Jukola, i Norge er det Night Hawk som gjelder. En stor orienteringsstafett arrangert av Tyrving IL som går i august. Damene har 6 etapper og herrene har 8 etapper. For både damer og herrer er halvparten av etappene på natta, og den andre halvparten på dagen.",
+    "description": "Night Hawk var Norges svar på Tiomila og Jukola — en stor orienteringsstafett arrangert av Tyrving IL i august. Damene hadde 6 etapper og herrene 8 etapper, og omtrent halvparten av stafetten foregikk i mørket. Stafetten ble arrangert siste gang i 2023 og er nå lagt ned.",
     "tags": [
       "stafett"
     ],

--- a/resources/orienteering_dictionary_da.json
+++ b/resources/orienteering_dictionary_da.json
@@ -350,7 +350,7 @@
   },
   {
     "name": "Night Hawk",
-    "description": "Night Hawk er Norges svar på Tiomila og Jukola — en stor orienteringsstafet, der afholdes i august. Damer løber 6 etaper og herrer 8 etaper, og cirka halvdelen af stafetten foregår om natten og halvdelen i dagslys. Arrangeret af den norske klub Tyrving IL.",
+    "description": "Night Hawk var Norges svar på Tiomila og Jukola — en stor orienteringsstafet afholdt i august af Tyrving IL. Damer løb 6 etaper og herrer 8 etaper, og cirka halvdelen af stafetten foregik om natten. Stafetten blev afholdt for sidste gang i 2023 og er nu nedlagt.",
     "tags": [
       "nattorientering"
     ],

--- a/resources/orienteering_dictionary_en.json
+++ b/resources/orienteering_dictionary_en.json
@@ -344,7 +344,7 @@
   },
   {
     "name": "Night Hawk",
-    "description": "Night Hawk is Norway's equivalent of Tiomila and Jukola — a major orienteering relay held in August, arranged by Tyrving IL. Women run 6 legs and men run 8 legs, with roughly half of each relay taking place in darkness and the other half in daylight.",
+    "description": "Night Hawk was Norway's equivalent of Tiomila and Jukola — a major orienteering relay held in August, arranged by Tyrving IL. Women ran 6 legs and men ran 8 legs, with roughly half of each relay taking place in darkness and the other half in daylight. The relay was last held in 2023 and has since been discontinued.",
     "tags": [
       "relay"
     ],

--- a/resources/orienteering_dictionary_sv.json
+++ b/resources/orienteering_dictionary_sv.json
@@ -340,7 +340,7 @@
   },
   {
     "name": "Night Hawk",
-    "description": "I Sverige har vi Tiomila, i Finland Jukola — i Norge är Night Hawk den stora stafetten. Night Hawk arrangeras i augusti av Tyrving IL och är en stor orienteringsstafett. Damerna har 6 etapper och herrarna 8 etapper, och ungefär hälften av varje stafett sker i mörker och hälften i dagsljus.",
+    "description": "Night Hawk var Norges svar på Tiomila och Jukola — en stor orienteringsstafett arrangerad i augusti av Tyrving IL. Damerna hade 6 etapper och herrarna 8 etapper, och ungefär hälften av stafetten skedde i mörker. Stafetten arrangerades sista gången 2023 och är nu nedlagd.",
     "tags": [
       "stafett"
     ],


### PR DESCRIPTION
Night Hawk was last arranged in 2023 and is now discontinued. Updated descriptions in all languages (no, en, sv, da) to use past tense and note it was last held in 2023.

Closes #106