### PR TITLE
fix: correct OribosTS link to official website

### DIFF
--- a/resources/orienteering_dictionary.json
+++ b/resources/orienteering_dictionary.json
@@ -479,7 +479,7 @@
   },
   {
     "name": "Sportiduino",
-    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> er et åpen kildekode-system for elektronisk tidtaking i orientering, og er et rimeligere alternativ til <a href=\"/#sportident\">SPORTIdent</a> og <a href=\"/#emit\">EMIT</a>. Systemet er basert på Arduino-plattformen, men krever betydelig tid og innsats å sette opp da man selv må bygge poster og brikkeleser. Et annet åpen kildekode-alternativ er <a href=\"https://github.com/oribos-ts\">OribosTS</a>.",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> er et åpen kildekode-system for elektronisk tidtaking i orientering, og er et rimeligere alternativ til <a href=\"/#sportident\">SPORTIdent</a> og <a href=\"/#emit\">EMIT</a>. Systemet er basert på Arduino-plattformen, men krever betydelig tid og innsats å sette opp da man selv må bygge poster og brikkeleser. Et annet åpen kildekode-alternativ er <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a>.",
     "tags": [
       "tidtaking"
     ],

--- a/resources/orienteering_dictionary_da.json
+++ b/resources/orienteering_dictionary_da.json
@@ -534,7 +534,7 @@
   },
   {
     "name": "Sportiduino",
-    "description": "Sportiduino er et open source-stempling- og tidtagningssystem baseret på Arduino-hardware. Det er designet til at give orienteringsklubber et billigt alternativ til kommercielle systemer som SPORTIdent eller EMIT. <a href=\"https://github.com/OribosTS/OribosTS\">OribosTS</a> er et andet open source-alternativ.",
+    "description": "Sportiduino er et open source-stempling- og tidtagningssystem baseret på Arduino-hardware. Det er designet til at give orienteringsklubber et billigt alternativ til kommercielle systemer som SPORTIdent eller EMIT. <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a> er et andet open source-alternativ.",
     "tags": [],
     "related": [
       "SPORTIdent",

--- a/resources/orienteering_dictionary_en.json
+++ b/resources/orienteering_dictionary_en.json
@@ -520,7 +520,7 @@
   },
   {
     "name": "Sportiduino",
-    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> is an open-source electronic timing system for orienteering, offering a lower-cost alternative to <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>. It is based on the Arduino platform; setting it up requires significant time and effort as controls and a chip reader must be built from components. Another open-source timing alternative is <a href=\"https://github.com/oribos-ts\">OribosTS</a>.",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> is an open-source electronic timing system for orienteering, offering a lower-cost alternative to <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>. It is based on the Arduino platform; setting it up requires significant time and effort as controls and a chip reader must be built from components. Another open-source timing alternative is <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a>.",
     "tags": [
       "timing"
     ],

--- a/resources/orienteering_dictionary_sv.json
+++ b/resources/orienteering_dictionary_sv.json
@@ -515,7 +515,7 @@
   },
   {
     "name": "Sportiduino",
-    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> är ett system med öppen källkod för elektronisk tidtagning i orientering och ett prisvärt alternativ till <a href=\"/#sportident\">SPORTIdent</a> och <a href=\"/#emit\">EMIT</a>. Det är baserat på Arduino-plattformen och kräver inga licenser, men ett visst mått av teknisk kompetens för att bygga kontroller och bricklösare. Ett annat alternativ med öppen källkod är <a href=\"https://github.com/oribos-ts\">OribosTS</a>.",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> är ett system med öppen källkod för elektronisk tidtagning i orientering och ett prisvärt alternativ till <a href=\"/#sportident\">SPORTIdent</a> och <a href=\"/#emit\">EMIT</a>. Det är baserat på Arduino-plattformen och kräver inga licenser, men ett visst mått av teknisk kompetens för att bygga kontroller och bricklösare. Ett annat alternativ med öppen källkod är <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a>.",
     "tags": [
       "tidtagning"
     ],


### PR DESCRIPTION
The OribosTS link was pointing to a GitHub repo instead of the official website. Fixed in all languages (no, en, sv, da).

Closes #104