### PR TITLE
feat: add Finnish (fi) orienteering glossary

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -101,6 +101,7 @@ const dictionaries = {
   en: require("./resources/orienteering_dictionary_en.json"),
   sv: require("./resources/orienteering_dictionary_sv.json"),
   da: require("./resources/orienteering_dictionary_da.json"),
+  fi: require("./resources/orienteering_dictionary_fi.json"),
 };
 
 const dictionaryMaps = Object.fromEntries(

--- a/resources/orienteering_dictionary_da.json
+++ b/resources/orienteering_dictionary_da.json
@@ -45,7 +45,7 @@
   },
   {
     "name": "EMIT",
-    "description": "EMIT er et elektronisk tidtagningssystem til orientering fremstillet af det norske firma EMIT. Det er det dominerende system i norsk og finsk orientering. Internationalt er <a href=\"/#sportident\">SPORTIdent</a> mere udbredt. <i>Se <a href=\"/#tidtaking\">tidtagning</a></i>.",
+    "description": "EMIT er et elektronisk tidtagningssystem til orientering fremstillet af det norske firma EMIT. Det er det dominerende system i norsk og finsk orientering. Internationalt er <a href=\"/da/#sportident\">SPORTIdent</a> mere udbredt. <i>Se <a href=\"/da/#tidtaking\">tidtagning</a></i>.",
     "tags": [],
     "related": [
       "emiTag",
@@ -58,7 +58,7 @@
   },
   {
     "name": "tidtagning",
-    "description": "Tidtagning handler om at registrere løbernes tider under et orienteringsløb. De mest almindelige systemer er <a href=\"/#emit\">EMIT</a> og <a href=\"/#sportident\">SPORTIdent</a>.",
+    "description": "Tidtagning handler om at registrere løbernes tider under et orienteringsløb. De mest almindelige systemer er <a href=\"/da/#emit\">EMIT</a> og <a href=\"/da/#sportident\">SPORTIdent</a>.",
     "tags": [],
     "related": [
       "EMIT",
@@ -71,7 +71,7 @@
   },
   {
     "name": "gafling",
-    "description": "Gafling bruges til at forhindre løbere i at <a href=\"/#henge\">hænge</a> efter hinanden. Løbere i samme klasse får baner, der er lidt forskellige — de fleste poster er fælles, men ved visse punkter skal nogle løbere besøge en post et stykke fra den, andre i klassen skal tage. Løberne skal navigere omhyggeligt for at stemple den rigtige post; stempler man den forkerte, bliver man diskvalificeret.",
+    "description": "Gafling bruges til at forhindre løbere i at <a href=\"/da/#henge\">hænge</a> efter hinanden. Løbere i samme klasse får baner, der er lidt forskellige — de fleste poster er fælles, men ved visse punkter skal nogle løbere besøge en post et stykke fra den, andre i klassen skal tage. Løberne skal navigere omhyggeligt for at stemple den rigtige post; stempler man den forkerte, bliver man diskvalificeret.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -184,7 +184,7 @@
   },
   {
     "name": "A-niveau",
-    "description": "A-niveau er det sværeste banesvanskelighetsgrad i det skandinaviske klassificeringssystem. Alle orienteringsteknikker kræves. <i>Se <a href=\"/#vanskelighetsgrad\">sværhedsgrad</a></i>.",
+    "description": "A-niveau er det sværeste banesvanskelighetsgrad i det skandinaviske klassificeringssystem. Alle orienteringsteknikker kræves. <i>Se <a href=\"/da/#vanskelighetsgrad\">sværhedsgrad</a></i>.",
     "tags": [
       "løpsnivå"
     ],
@@ -198,7 +198,7 @@
   },
   {
     "name": "B-niveau",
-    "description": "B-niveau er det næstsværeste banesvanskelighetsgrad i det skandinaviske klassificeringssystem. B-baner kræver kort finorientering ind mod posten og forståelse for højdekurver. <i>Se <a href=\"/#vanskelighetsgrad\">sværhedsgrad</a></i>.",
+    "description": "B-niveau er det næstsværeste banesvanskelighetsgrad i det skandinaviske klassificeringssystem. B-baner kræver kort finorientering ind mod posten og forståelse for højdekurver. <i>Se <a href=\"/da/#vanskelighetsgrad\">sværhedsgrad</a></i>.",
     "tags": [
       "løpsnivå"
     ],
@@ -212,7 +212,7 @@
   },
   {
     "name": "C-niveau",
-    "description": "C-niveau er det næstlettest banesvanskelighetsgrad i det skandinaviske klassificeringssystem. C-baner følger for det meste <a href=\"/#ledelinje\">ledelinjer</a>, men løberne forventes at forlade ledelinjerne på visse steder. Der kan være veivalgsmuligheder. <i>Se <a href=\"/#vanskelighetsgrad\">sværhedsgrad</a></i>.",
+    "description": "C-niveau er det næstlettest banesvanskelighetsgrad i det skandinaviske klassificeringssystem. C-baner følger for det meste <a href=\"/da/#ledelinje\">ledelinjer</a>, men løberne forventes at forlade ledelinjerne på visse steder. Der kan være veivalgsmuligheder. <i>Se <a href=\"/da/#vanskelighetsgrad\">sværhedsgrad</a></i>.",
     "tags": [
       "løpsnivå"
     ],
@@ -226,7 +226,7 @@
   },
   {
     "name": "N-niveau (begynder)",
-    "description": "N-niveau er det lettest banesvanskelighetsgrad i det skandinaviske klassificeringssystem, beregnet til nybegyndere. N-baner følger sammenhængende <a href=\"/#ledelinje\">ledelinjer</a> som stier, spor, bække og hegn, og alle poster kan ses fra ledelinjerne. <i>Se <a href=\"/#vanskelighetsgrad\">sværhedsgrad</a></i>.",
+    "description": "N-niveau er det lettest banesvanskelighetsgrad i det skandinaviske klassificeringssystem, beregnet til nybegyndere. N-baner følger sammenhængende <a href=\"/da/#ledelinje\">ledelinjer</a> som stier, spor, bække og hegn, og alle poster kan ses fra ledelinjerne. <i>Se <a href=\"/da/#vanskelighetsgrad\">sværhedsgrad</a></i>.",
     "tags": [
       "løpsnivå"
     ],
@@ -242,7 +242,7 @@
   },
   {
     "name": "sværhedsgrad",
-    "description": "I det skandinaviske klassificeringssystem inddeles baner i fire sværhedsgrader: <a href=\"/#a-niv\">A</a>, <a href=\"/#b-niv\">B</a>, <a href=\"/#c-niv\">C</a> og <a href=\"/#n-niv\">N</a>, hvor A er sværest og N er nybegynderbaner. Andre lande bruger andre systemer — i Danmark bruges f.eks. Nem, Middel og Svær (N, M og S).",
+    "description": "I det skandinaviske klassificeringssystem inddeles baner i fire sværhedsgrader: <a href=\"/da/#a-niv\">A</a>, <a href=\"/da/#b-niv\">B</a>, <a href=\"/da/#c-niv\">C</a> og <a href=\"/da/#n-niv\">N</a>, hvor A er sværest og N er nybegynderbaner. Andre lande bruger andre systemer — i Danmark bruges f.eks. Nem, Middel og Svær (N, M og S).",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -280,7 +280,7 @@
   },
   {
     "name": "O",
-    "description": "I orientering er man glad for bogstavet O og bruger det, så ofte man kan: o-sko (<a href=\"/#orienteringssko\">orienteringssko</a>), o-træning (orienteringstræning), o-tøj, o-sport og o-hilsen. Det er en forkortelse for orientering, der bruges flittigt i orienteringskulturen.",
+    "description": "I orientering er man glad for bogstavet O og bruger det, så ofte man kan: o-sko (<a href=\"/da/#orienteringssko\">orienteringssko</a>), o-træning (orienteringstræning), o-tøj, o-sport og o-hilsen. Det er en forkortelse for orientering, der bruges flittigt i orienteringskulturen.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -308,7 +308,7 @@
   },
   {
     "name": "georeferere",
-    "description": "At georeferere et kort betyder at knytte det til geografiske koordinater, så det kan vises og bruges i digitale kortapplikationer. Dette kræves bl.a. for værktøjer som <a href=\"/#livelox\">Livelox</a>.",
+    "description": "At georeferere et kort betyder at knytte det til geografiske koordinater, så det kan vises og bruges i digitale kortapplikationer. Dette kræves bl.a. for værktøjer som <a href=\"/da/#livelox\">Livelox</a>.",
     "tags": [],
     "related": [
       "Livelox"
@@ -401,7 +401,7 @@
   },
   {
     "name": "præcisionsorientering",
-    "description": "Præcisionsorientering (pre-O) er en IOF-anerkendt gren, der er tilgængelig for både bevægelseshæmmede og raske deltagere. Banerne følger stier og veje, der er tilgængelige for kørestole. Udfordringen er kortlæsningsnøjagtighed snarere end løbehastighed — ved hvert kontrolpunkt er der placeret flere skærme, og deltageren skal afgøre, hvilken (om nogen) der stemmer overens med kortet og <a href=\"/#postbeskrivelse\">postbeskrivelsen</a>.",
+    "description": "Præcisionsorientering (pre-O) er en IOF-anerkendt gren, der er tilgængelig for både bevægelseshæmmede og raske deltagere. Banerne følger stier og veje, der er tilgængelige for kørestole. Udfordringen er kortlæsningsnøjagtighed snarere end løbehastighed — ved hvert kontrolpunkt er der placeret flere skærme, og deltageren skal afgøre, hvilken (om nogen) der stemmer overens med kortet og <a href=\"/da/#postbeskrivelse\">postbeskrivelsen</a>.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -455,7 +455,7 @@
   },
   {
     "name": "turorientering",
-    "description": "Turorientering (TRIM-O) er en ikke-konkurrencepræget form for orientering, hvor man finder poster ved hjælp af et kort uden tidtagning eller præmier. Se også <a href=\"/#stolpejakten\">Stolpejakten</a>.",
+    "description": "Turorientering (TRIM-O) er en ikke-konkurrencepræget form for orientering, hvor man finder poster ved hjælp af et kort uden tidtagning eller præmier. Se også <a href=\"/da/#stolpejakten\">Stolpejakten</a>.",
     "tags": [],
     "related": [
       "Stolpejakten"
@@ -467,7 +467,7 @@
   },
   {
     "name": "Stolpejakten",
-    "description": "Stolpejakten (norsk: 'stolpejagten') er en aktivitet arrangeret af det norske orienteringsforbund, hvor deltagerne finder permanente orienteringsposter ved hjælp af et kort. Der er ingen tidtagning — deltagerne går i eget tempo. Aktiviteten minder om <a href=\"/#turorientering\">turorientering</a>.",
+    "description": "Stolpejakten (norsk: 'stolpejagten') er en aktivitet arrangeret af det norske orienteringsforbund, hvor deltagerne finder permanente orienteringsposter ved hjælp af et kort. Der er ingen tidtagning — deltagerne går i eget tempo. Aktiviteten minder om <a href=\"/da/#turorientering\">turorientering</a>.",
     "tags": [],
     "related": [
       "turorientering"
@@ -509,7 +509,7 @@
   },
   {
     "name": "cirklen",
-    "description": "Cirklen er den ring på orienteringskortet, der markerer kontrolpunktets nøjagtige position. Cirklen er centreret om det præcise terrænpunkt, der skal opsøges. <i>Se også <a href=\"/#postbeskrivelse\">kontrolbeskrivelse</a></i>.",
+    "description": "Cirklen er den ring på orienteringskortet, der markerer kontrolpunktets nøjagtige position. Cirklen er centreret om det præcise terrænpunkt, der skal opsøges. <i>Se også <a href=\"/da/#postbeskrivelse\">kontrolbeskrivelse</a></i>.",
     "tags": [],
     "related": [],
     "aliases": [

--- a/resources/orienteering_dictionary_en.json
+++ b/resources/orienteering_dictionary_en.json
@@ -46,7 +46,7 @@
   },
   {
     "name": "EMIT",
-    "description": "EMIT is an electronic timing system for orienteering produced by the Norwegian company EMIT. It is the dominant timing system in Norwegian and Finnish orienteering. Internationally, <a href=\"/#sportident\">SPORTIdent</a> is the more widely used standard. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "description": "EMIT is an electronic timing system for orienteering produced by the Norwegian company EMIT. It is the dominant timing system in Norwegian and Finnish orienteering. Internationally, <a href=\"/en/#sportident\">SPORTIdent</a> is the more widely used standard. <i>See <a href=\"/en/#timing\">timing</a></i>.",
     "tags": [
       "timing"
     ],
@@ -60,7 +60,7 @@
   },
   {
     "name": "timing",
-    "description": "Electronic timing in orienteering works via a personal timing chip registered to each competitor. When a runner arrives at a control, they punch their chip on the timing unit at that control, recording the visit. At the finish the chip is downloaded and the total time and split times between controls are displayed. The two most common systems are <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>.",
+    "description": "Electronic timing in orienteering works via a personal timing chip registered to each competitor. When a runner arrives at a control, they punch their chip on the timing unit at that control, recording the visit. At the finish the chip is downloaded and the total time and split times between controls are displayed. The two most common systems are <a href=\"/en/#sportident\">SPORTIdent</a> and <a href=\"/en/#emit\">EMIT</a>.",
     "tags": [
       "timing"
     ],
@@ -74,7 +74,7 @@
   },
   {
     "name": "forking",
-    "description": "Forking is used to prevent competitors from <a href=\"/#following\">following</a> each other around the course. Runners in the same class receive courses that differ slightly — most controls are shared, but at certain points some runners must visit a control a short distance away from the one others in the same class visit. Runners must navigate carefully to punch the correct control; punching the wrong one results in disqualification.",
+    "description": "Forking is used to prevent competitors from <a href=\"/en/#following\">following</a> each other around the course. Runners in the same class receive courses that differ slightly — most controls are shared, but at certain points some runners must visit a control a short distance away from the one others in the same class visit. Runners must navigate carefully to punch the correct control; punching the wrong one results in disqualification.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -92,7 +92,7 @@
   },
   {
     "name": "SPORTIdent",
-    "description": "<a href=\"https://www.sportident.com/\">SPORTIdent</a> is the most widely used electronic timing system in international orienteering. The personal chip is called an SI-card (or dibber in the UK). SPORTIdent is the standard at World Championships and the dominant system across Europe, the UK, and Australia. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "description": "<a href=\"https://www.sportident.com/\">SPORTIdent</a> is the most widely used electronic timing system in international orienteering. The personal chip is called an SI-card (or dibber in the UK). SPORTIdent is the standard at World Championships and the dominant system across Europe, the UK, and Australia. <i>See <a href=\"/en/#timing\">timing</a></i>.",
     "tags": [
       "timing"
     ],
@@ -137,7 +137,7 @@
   },
   {
     "name": "map",
-    "description": "An orienteering map shows the terrain in a simplified format and is the primary tool a runner uses to navigate between controls. It uses a rich set of symbols: contour lines show elevation, black dots indicate boulders, blue areas show water, and so on. Maps are produced at different <i><a href=\"/#scale\">scales</a></i>, typically 1:5000 for sprint orienteering and 1:10000 for forest orienteering.",
+    "description": "An orienteering map shows the terrain in a simplified format and is the primary tool a runner uses to navigate between controls. It uses a rich set of symbols: contour lines show elevation, black dots indicate boulders, blue areas show water, and so on. Maps are produced at different <i><a href=\"/en/#scale\">scales</a></i>, typically 1:5000 for sprint orienteering and 1:10000 for forest orienteering.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -153,7 +153,7 @@
   },
   {
     "name": "compass",
-    "description": "A compass indicates the direction of north (and therefore south, east, and west). An orienteer uses a compass to hold a bearing towards the next <i><a href=\"/#control\">control</a></i>, or to set the map — rotating it to align with the surrounding terrain.",
+    "description": "A compass indicates the direction of north (and therefore south, east, and west). An orienteer uses a compass to hold a bearing towards the next <i><a href=\"/en/#control\">control</a></i>, or to set the map — rotating it to align with the surrounding terrain.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -161,7 +161,7 @@
   },
   {
     "name": "control",
-    "description": "An orienteering control (also called a flag or post) consists of an orange-and-white marker flag and an attached timing unit used to record a competitor's visit to that point. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "description": "An orienteering control (also called a flag or post) consists of an orange-and-white marker flag and an attached timing unit used to record a competitor's visit to that point. <i>See <a href=\"/en/#timing\">timing</a></i>.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -172,7 +172,7 @@
   },
   {
     "name": "thumb compass",
-    "description": "A thumb compass is strapped to the thumb, allowing the runner to hold the map and compass together as one unit — the most popular style among orienteers. Traditional plate compasses are also used but are less common in competition. <i>See <a href=\"/#compass\">compass</a></i>.",
+    "description": "A thumb compass is strapped to the thumb, allowing the runner to hold the map and compass together as one unit — the most popular style among orienteers. Traditional plate compasses are also used but are less common in competition. <i>See <a href=\"/en/#compass\">compass</a></i>.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -180,7 +180,7 @@
   },
   {
     "name": "A-level",
-    "description": "A-level is the most technically demanding course difficulty in the Scandinavian grading system. All orienteering techniques are required. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
+    "description": "A-level is the most technically demanding course difficulty in the Scandinavian grading system. All orienteering techniques are required. <i>See <a href=\"/en/#difficulty-level\">difficulty level</a></i>.",
     "tags": [],
     "related": [
       "B-level",
@@ -192,7 +192,7 @@
   },
   {
     "name": "B-level",
-    "description": "B-level is the second most difficult course grade in the Scandinavian grading system. B-level courses require short fine-navigation legs into the control and a good understanding of contour lines. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
+    "description": "B-level is the second most difficult course grade in the Scandinavian grading system. B-level courses require short fine-navigation legs into the control and a good understanding of contour lines. <i>See <a href=\"/en/#difficulty-level\">difficulty level</a></i>.",
     "tags": [],
     "related": [
       "A-level",
@@ -204,7 +204,7 @@
   },
   {
     "name": "C-level",
-    "description": "C-level is the second easiest course grade in the Scandinavian grading system. C-level courses mostly follow <a href=\"/#handrail\">handrails</a>, but runners are expected to leave handrails at certain points. Route choice opportunities may exist. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
+    "description": "C-level is the second easiest course grade in the Scandinavian grading system. C-level courses mostly follow <a href=\"/en/#handrail\">handrails</a>, but runners are expected to leave handrails at certain points. Route choice opportunities may exist. <i>See <a href=\"/en/#difficulty-level\">difficulty level</a></i>.",
     "tags": [],
     "related": [
       "A-level",
@@ -216,7 +216,7 @@
   },
   {
     "name": "N-level",
-    "description": "N-level is the easiest course grade in the Scandinavian grading system, designed for beginners. N-level courses follow continuous <a href=\"/#handrail\">handrails</a> such as paths, tracks, streams, and fences, with all controls visible from the handrail. <i>See <a href=\"/#difficulty-level\">difficulty level</a></i>.",
+    "description": "N-level is the easiest course grade in the Scandinavian grading system, designed for beginners. N-level courses follow continuous <a href=\"/en/#handrail\">handrails</a> such as paths, tracks, streams, and fences, with all controls visible from the handrail. <i>See <a href=\"/en/#difficulty-level\">difficulty level</a></i>.",
     "tags": [],
     "related": [
       "A-level",
@@ -228,7 +228,7 @@
   },
   {
     "name": "difficulty level",
-    "description": "In the Scandinavian grading system, courses are divided into four difficulty levels: <a href=\"/#a-level\">A</a>, <a href=\"/#b-level\">B</a>, <a href=\"/#c-level\">C</a>, and <a href=\"/#n-level\">N</a>, where A is the hardest and N is a beginner course. Other countries use colour-coded systems — the UK uses White, Yellow, Orange, Light Green, Green, Blue, and Brown; Australia uses White, Yellow, Orange, Red, and Blue.",
+    "description": "In the Scandinavian grading system, courses are divided into four difficulty levels: <a href=\"/en/#a-level\">A</a>, <a href=\"/en/#b-level\">B</a>, <a href=\"/en/#c-level\">C</a>, and <a href=\"/en/#n-level\">N</a>, where A is the hardest and N is a beginner course. Other countries use colour-coded systems — the UK uses White, Yellow, Orange, Light Green, Green, Blue, and Brown; Australia uses White, Yellow, Orange, Red, and Blue.",
     "tags": [],
     "related": [
       "A-level",
@@ -276,7 +276,7 @@
   },
   {
     "name": "O",
-    "description": "Orienteers love the letter O and use it wherever possible: o-shoes (<a href=\"/#orienteering-shoes\">orienteering shoes</a>), o-training (orienteering training), o-suit, o-sport, and so on. It is shorthand for orienteering and is widely used in English-speaking clubs as well as Scandinavian ones.",
+    "description": "Orienteers love the letter O and use it wherever possible: o-shoes (<a href=\"/en/#orienteering-shoes\">orienteering shoes</a>), o-training (orienteering training), o-suit, o-sport, and so on. It is shorthand for orienteering and is widely used in English-speaking clubs as well as Scandinavian ones.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -365,7 +365,7 @@
   },
   {
     "name": "retire",
-    "description": "If you are injured or hopelessly lost, you may retire from the race. Find the quickest safe route back to the <a href=\"/#event-centre\">event centre</a>. It is essential to report to the finish or download station even when retiring, so officials know you are safe and do not launch a search. Runners who retire are recorded as DNF (Did Not Finish) on the results.",
+    "description": "If you are injured or hopelessly lost, you may retire from the race. Find the quickest safe route back to the <a href=\"/en/#event-centre\">event centre</a>. It is essential to report to the finish or download station even when retiring, so officials know you are safe and do not launch a search. Runners who retire are recorded as DNF (Did Not Finish) on the results.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -386,7 +386,7 @@
   },
   {
     "name": "trail orienteering",
-    "description": "Trail orienteering (pre-O) is the IOF-recognised discipline designed to be accessible to both able-bodied and mobility-impaired participants. Courses follow paths and tracks accessible by wheelchair. The challenge is map-reading accuracy rather than running speed — at each control site, several markers are placed and the competitor must identify which one (if any) matches the map and <a href=\"/#control-description\">control description</a>. Some controls have a single marker where the task is to decide which of several control descriptions is correct.",
+    "description": "Trail orienteering (pre-O) is the IOF-recognised discipline designed to be accessible to both able-bodied and mobility-impaired participants. Courses follow paths and tracks accessible by wheelchair. The challenge is map-reading accuracy rather than running speed — at each control site, several markers are placed and the competitor must identify which one (if any) matches the map and <a href=\"/en/#control-description\">control description</a>. Some controls have a single marker where the task is to decide which of several control descriptions is correct.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -407,7 +407,7 @@
   },
   {
     "name": "contour interval",
-    "description": "The contour interval is the difference in elevation between two adjacent contour lines (the brown lines on an orienteering map). A smaller contour interval allows more elevation detail to be shown. On most orienteering maps the contour interval is 5 metres. See <a href=\"/#index-contour\">index contour</a>.",
+    "description": "The contour interval is the difference in elevation between two adjacent contour lines (the brown lines on an orienteering map). A smaller contour interval allows more elevation detail to be shown. On most orienteering maps the contour interval is 5 metres. See <a href=\"/en/#index-contour\">index contour</a>.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -415,7 +415,7 @@
   },
   {
     "name": "index contour",
-    "description": "Every fifth contour line on a map is drawn thicker — this is an index contour. Index contours make it quick and easy to calculate larger height differences. With a <a href=\"/#contour-interval\">contour interval</a> of 5 metres, each index contour represents 25 metres of elevation. Three index contours between you and your next control therefore means 75 metres of climbing.",
+    "description": "Every fifth contour line on a map is drawn thicker — this is an index contour. Index contours make it quick and easy to calculate larger height differences. With a <a href=\"/en/#contour-interval\">contour interval</a> of 5 metres, each index contour represents 25 metres of elevation. Three index contours between you and your next control therefore means 75 metres of climbing.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -485,7 +485,7 @@
   },
   {
     "name": "control circle",
-    "description": "The control circle is the circle printed on the orienteering map marking the exact position of a control. The circle is centred on the precise feature to be found. <i>See also <a href=\"/#control-description\">control description</a></i>.",
+    "description": "The control circle is the circle printed on the orienteering map marking the exact position of a control. The circle is centred on the precise feature to be found. <i>See also <a href=\"/en/#control-description\">control description</a></i>.",
     "tags": [],
     "related": [
       "map",
@@ -507,7 +507,7 @@
   },
   {
     "name": "pin punch",
-    "description": "A pin punch is the traditional manual punching tool used in orienteering before electronic timing. When pressed against a punch card it leaves a unique pattern of holes, proving a competitor visited that control. Pin punches are rarely seen in modern competitions. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "description": "A pin punch is the traditional manual punching tool used in orienteering before electronic timing. When pressed against a punch card it leaves a unique pattern of holes, proving a competitor visited that control. Pin punches are rarely seen in modern competitions. <i>See <a href=\"/en/#timing\">timing</a></i>.",
     "tags": [
       "timing"
     ],
@@ -520,7 +520,7 @@
   },
   {
     "name": "Sportiduino",
-    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> is an open-source electronic timing system for orienteering, offering a lower-cost alternative to <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>. It is based on the Arduino platform; setting it up requires significant time and effort as controls and a chip reader must be built from components. Another open-source timing alternative is <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a>.",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> is an open-source electronic timing system for orienteering, offering a lower-cost alternative to <a href=\"/en/#sportident\">SPORTIdent</a> and <a href=\"/en/#emit\">EMIT</a>. It is based on the Arduino platform; setting it up requires significant time and effort as controls and a chip reader must be built from components. Another open-source timing alternative is <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a>.",
     "tags": [
       "timing"
     ],
@@ -534,7 +534,7 @@
   },
   {
     "name": "SIAC",
-    "description": "SIAC (SPORTIdent Air+ Card) is SPORTIdent's contactless timing chip. Unlike a standard SI-card, the SIAC does not need to be physically inserted into the control unit — it registers automatically when held close enough, then beeps and flashes to confirm a valid punch. SIAC requires controls equipped with Air+ units. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "description": "SIAC (SPORTIdent Air+ Card) is SPORTIdent's contactless timing chip. Unlike a standard SI-card, the SIAC does not need to be physically inserted into the control unit — it registers automatically when held close enough, then beeps and flashes to confirm a valid punch. SIAC requires controls equipped with Air+ units. <i>See <a href=\"/en/#timing\">timing</a></i>.",
     "tags": [
       "timing"
     ],
@@ -551,7 +551,7 @@
   },
   {
     "name": "emiTag",
-    "description": "The emiTag is EMIT's contactless timing chip — the equivalent of <a href=\"/#siac\">SIAC</a> for the SPORTIdent system. It registers automatically as it passes close to the control unit without needing physical insertion. Used at events running the EMIT system. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "description": "The emiTag is EMIT's contactless timing chip — the equivalent of <a href=\"/en/#siac\">SIAC</a> for the SPORTIdent system. It registers automatically as it passes close to the control unit without needing physical insertion. Used at events running the EMIT system. <i>See <a href=\"/en/#timing\">timing</a></i>.",
     "tags": [
       "timing"
     ],
@@ -566,7 +566,7 @@
   },
   {
     "name": "Huichang",
-    "description": "Huichang is a Chinese electronic timing system for orienteering, produced by Beijing Huichang Sports Technology. It is the dominant timing system in Chinese orienteering and is widely used across Asia. It operates on the same principles as <a href=\"/#sportident\">SPORTIdent</a> and <a href=\"/#emit\">EMIT</a>. <i>See <a href=\"/#timing\">timing</a></i>.",
+    "description": "Huichang is a Chinese electronic timing system for orienteering, produced by Beijing Huichang Sports Technology. It is the dominant timing system in Chinese orienteering and is widely used across Asia. It operates on the same principles as <a href=\"/en/#sportident\">SPORTIdent</a> and <a href=\"/en/#emit\">EMIT</a>. <i>See <a href=\"/en/#timing\">timing</a></i>.",
     "tags": [
       "timing"
     ],

--- a/resources/orienteering_dictionary_fi.json
+++ b/resources/orienteering_dictionary_fi.json
@@ -1,0 +1,588 @@
+[
+  {
+    "name": "PM",
+    "description": "PM (promemoria) on suunnistuskilpailun kilpailuohje — yksityiskohtainen tietopaketti kilpailusta, kuten tarkka lähtöpaikan sijainti, pysäköintiohjeet ja juomapisteiden tiedot. PM laaditaan yleensä vain suuremmille kilpailuille.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "promemoria",
+      "kilpailuohje"
+    ],
+    "id": "PM"
+  },
+  {
+    "name": "kilpailukeskus",
+    "description": "Kilpailukeskus (tunnetaan myös nimellä areena) on suunnistuskilpailun toiminnan keskipiste. Sieltä löytyvät maali, latausasema, toimitsijat, tulostaulu, palkintojenjako sekä usein suihkut ja virvokkeet. Lähtö sijaitsee usein muualla, mutta sinne on opastettu kilpailukeskuksesta.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "areena"
+    ],
+    "id": "samlingsplass"
+  },
+  {
+    "name": "viesti",
+    "description": "Viesti on joukkuemuoto, jossa kukin joukkueenjäsen juoksee yhden tai useamman osuuden ja vaihtaa seuraavalle juoksijalle osuuden päättyessä. Skandinaviassa käytetään myös sanoja <i>kavle</i> ja <i>budkavle</i>.",
+    "tags": [
+      "viesti"
+    ],
+    "related": [],
+    "aliases": [
+      "staffetti",
+      "kavle"
+    ],
+    "id": "kavle"
+  },
+  {
+    "name": "harhailu",
+    "description": "Harhailu tarkoittaa tilannetta, jossa suunnistaja ei löydä rastiaan sujuvasti ja menettää aikaa. Eliittisuunnistajalle pieni harhailu voi tarkoittaa 10–20 sekunnin menetystä, aloittelijalle taas useita minuutteja tai pahimmillaan kymmeniä minuutteja.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "erehdys",
+      "moka"
+    ],
+    "id": "bomme"
+  },
+  {
+    "name": "EMIT",
+    "description": "EMIT on norjalaisen EMIT-yrityksen valmistama elektroninen ajanottojärjestelmä suunnistukseen. Se on hallitseva järjestelmä Suomessa ja Norjassa. Kansainvälisesti <a href=\"/#sportident\">SPORTIdent</a> on yleisempi standardi. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "tags": [
+      "ajanotto"
+    ],
+    "related": [
+      "SPORTIdent",
+      "SFR",
+      "emiTag"
+    ],
+    "aliases": [],
+    "id": "EMIT"
+  },
+  {
+    "name": "ajanotto",
+    "description": "Elektroninen ajanotto suunnistuksessa perustuu henkilökohtaiseen brikki-siruun, joka on rekisteröity kullekin kilpailijalle. Kun juoksija saapuu rastille, hän leimaa brikinsä rastin leimasimeen, jolloin käynti rekisteröityy. Maalissa brikki luetaan ja saadaan kokonaisaika sekä välitulokset rastien väliltä. Yleisimmät järjestelmät ovat <a href=\"/#emit\">EMIT</a> ja <a href=\"/#sportident\">SPORTIdent</a>.",
+    "tags": [
+      "ajanotto"
+    ],
+    "related": [
+      "EMIT",
+      "SPORTIdent",
+      "SFR"
+    ],
+    "aliases": [],
+    "id": "tidtaking"
+  },
+  {
+    "name": "haarukointi",
+    "description": "Haarukoinnilla estetään kilpailijoita <a href=\"/#seuraaminen\">seuraamasta</a> toisiaan radalla. Saman sarjan juoksijat saavat hieman toisistaan poikkeavat radat — useimmat rastit ovat yhteisiä, mutta tietyissä kohdissa eri juoksijat käyvät eri rasteilla. Juoksijoiden on navigoitava huolellisesti leimatakseen oikean rastin; väärän rastin leimaaminen johtaa diskvalifikaatioon.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "gafling"
+  },
+  {
+    "name": "rastikuvaus",
+    "description": "Rastikuvaus on kartan mukana tuleva lappunen, joka voidaan myös painaa suoraan kartalle. Siinä käytetään IOF:n standardoituja symboleja ilmaisemaan tarkasti, mille maastokohteelle kukin rasti on sijoitettu — esimerkiksi rasti 3 on suuren kiven länsipuolella.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "rastiselitys"
+    ],
+    "id": "postbeskrivelse"
+  },
+  {
+    "name": "SPORTIdent",
+    "description": "<a href=\"https://www.sportident.com/\">SPORTIdent</a> on kansainvälisesti eniten käytetty elektroninen ajanottojärjestelmä suunnistuksessa. Henkilökohtaista brikki-sirua kutsutaan SI-brikki:ksi. SPORTIdent on käytössä MM-kilpailuissa ja hallitseva järjestelmä Ruotsissa sekä suurimmassa osassa Eurooppaa. Suomessa ja Norjassa <a href=\"/#emit\">EMIT</a> on yleisempi. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "tags": [
+      "ajanotto"
+    ],
+    "related": [
+      "EMIT",
+      "SFR",
+      "SIAC"
+    ],
+    "aliases": [
+      "SI"
+    ],
+    "id": "SPORTIdent"
+  },
+  {
+    "name": "SFR",
+    "description": "<a href=\"http://sfr-system.com/\">SFR</a> (Start Finish Result) on venäläinen suunnistuksen elektroninen ajanottojärjestelmä, joka toimii samalla periaatteella kuin SPORTIdent ja EMIT.",
+    "tags": [
+      "ajanotto"
+    ],
+    "related": [
+      "EMIT",
+      "SPORTIdent"
+    ],
+    "aliases": [],
+    "id": "SFR"
+  },
+  {
+    "name": "Rankingløp",
+    "description": "Rankingløp on viikoittain järjestettävä epävirallinen harjoituskilpailusarja, jonka OSI Orientering ja IL GeoForm organisoivat Oslossa. Pisteitä kertyy kauden aikana kokonaissijoitukseen — siitä nimi. Lisätietoja <a href=\"https://ilgeoform.no/rankinglop/\">Rankingløp-sivulla</a>.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "Rankingløp"
+  },
+  {
+    "name": "Rastilippu",
+    "description": "<a href=\"https://rastilippu.fi\">Rastilippu</a> on Suomen Suunnistusliiton ylläpitämä kilpailukalenteri ja ilmoittautumisjärjestelmä. Sieltä löytyvät suunnistuskilpailujen terminlista, ilmoittautumiset ja tulokset. Rekisteröi tunnus kilpailuihin verkossa ilmoittautumista varten. Muissa Pohjoismaissa käytetään vastaavaan tarkoitukseen <a href=\"http://eventor.orientering.no\">Eventor</a>-palvelua.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "Irma"
+    ],
+    "id": "Eventor"
+  },
+  {
+    "name": "kartta",
+    "description": "Suunnistuskartta esittää maaston pelkistetyssä muodossa ja on tärkein väline rastien välillä navigointiin. Kartassa on runsaasti symboleja: korkeuskäyrät kuvaavat korkeuseroja, mustat pisteet tarkoittavat kiviä, siniset alueet vettä ja niin edelleen. Karttoja painetaan eri <i><a href=\"/#mittakaava\">mittakaavoissa</a></i>, tyypillisesti 1:5000 sprinttisuunnistuksessa ja 1:10000 metsäsuunnistuksessa.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "suunnistuskartta"
+    ],
+    "id": "kart"
+  },
+  {
+    "name": "mittakaava",
+    "description": "Mittakaava kertoo, kuinka paljon todellinen maasto on pienennetty kartaksi. Mittakaava 1:10000 tarkoittaa, että 1 cm kartalla vastaa 10000 cm (100 metriä) maastossa. Retkeilykartat käyttävät usein mittakaavaa 1:50000 kattaen laajan alueen vähäisellä yksityiskohtaisuudella. Suunnistuskartat ovat tyypillisesti 1:7500 tai 1:10000 metsäradoilla ja 1:5000 tai 1:4000 sprintissä. Pienemmällä mittakaavalla kartalle mahtuu enemmän yksityiskohtia, mikä mahdollistaa tarkemman navigoinnin.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "målestokk"
+  },
+  {
+    "name": "kompassi",
+    "description": "Kompassi osoittaa pohjoisen (ja siten etelän, idän ja lännen) suunnan. Suunnistaja käyttää kompassia pitääkseen suunnan seuraavalle <i><a href=\"/#rasti\">rastille</a></i> tai asettaakseen kartan — kääntääkseen sen vastaamaan ympäröivää maastoa.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "kompass"
+  },
+  {
+    "name": "rasti",
+    "description": "Suunnistusrasti (kutsutaan myös postiksi tai merkiksi) koostuu oranssi-valkoisesta viirustasta ja siihen kiinnitetystä leimasimesta, jolla kilpailijan käynti rastilla rekisteröidään. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "kontrolli",
+      "posti"
+    ],
+    "id": "orienteringspost"
+  },
+  {
+    "name": "peukalokompassi",
+    "description": "Peukalokompassi kiinnitetään peukaloon, jolloin kartta ja kompassi voidaan pitää yhtenä kokonaisuutena — suosituin kompassityyppi suunnistajien keskuudessa. Perinteisiä levykompasseja käytetään myös, mutta ne ovat harvinaisempia kilpailuissa. <i>Katso <a href=\"/#kompassi\">kompassi</a></i>.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "tommelkompass"
+  },
+  {
+    "name": "A-taso",
+    "description": "A-taso on teknisesti vaativin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä. Kaikkien suunnistustekniikoiden hallitseminen on tarpeen. <i>Katso <a href=\"/#vaikeusaste\">vaikeusaste</a></i>.",
+    "tags": [],
+    "related": [
+      "B-nivå",
+      "C-nivå",
+      "N-nivå"
+    ],
+    "aliases": [],
+    "id": "A-nivå"
+  },
+  {
+    "name": "B-taso",
+    "description": "B-taso on toiseksi vaativin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä. B-radat edellyttävät lyhyttä hienosuunnistusta rastille sekä korkeuskäyrien hyvää ymmärtämistä. <i>Katso <a href=\"/#vaikeusaste\">vaikeusaste</a></i>.",
+    "tags": [],
+    "related": [
+      "A-nivå",
+      "C-nivå",
+      "N-nivå"
+    ],
+    "aliases": [],
+    "id": "B-nivå"
+  },
+  {
+    "name": "C-taso",
+    "description": "C-taso on toiseksi helpoin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä. C-radat seuraavat pääosin <a href=\"/#johtolinja\">johtolinjoja</a>, mutta juoksijoiden odotetaan poikkeavan niiltä tietyissä kohdissa. Reitinvalintamahdollisuuksia voi esiintyä. <i>Katso <a href=\"/#vaikeusaste\">vaikeusaste</a></i>.",
+    "tags": [],
+    "related": [
+      "A-nivå",
+      "B-nivå",
+      "N-nivå"
+    ],
+    "aliases": [],
+    "id": "C-nivå"
+  },
+  {
+    "name": "N-taso",
+    "description": "N-taso on helpoin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä, tarkoitettu aloittelijoille. N-radat seuraavat yhtenäisiä <a href=\"/#johtolinja\">johtolinjoja</a>, kuten polkuja, uria, puroja ja aitoja, ja kaikki rastit näkyvät johtolinjoilta. <i>Katso <a href=\"/#vaikeusaste\">vaikeusaste</a></i>.",
+    "tags": [],
+    "related": [
+      "A-nivå",
+      "B-nivå",
+      "C-nivå"
+    ],
+    "aliases": [],
+    "id": "N-nivå"
+  },
+  {
+    "name": "vaikeusaste",
+    "description": "Pohjoismaisessa luokittelujärjestelmässä radat jaetaan neljään vaikeusasteeseen: <a href=\"/#a-taso\">A</a>, <a href=\"/#b-taso\">B</a>, <a href=\"/#c-taso\">C</a> ja <a href=\"/#n-taso\">N</a>, joista A on vaikein ja N on aloittelijoille tarkoitettu. Tätä järjestelmää käytetään Suomessa, Norjassa ja Ruotsissa. Muissa maissa käytetään erilaisia väri- tai numeropohjaisia järjestelmiä.",
+    "tags": [],
+    "related": [
+      "A-nivå",
+      "B-nivå",
+      "C-nivå",
+      "N-nivå"
+    ],
+    "aliases": [],
+    "id": "vanskelighetsgrad"
+  },
+  {
+    "name": "seuraaminen",
+    "description": "Seuraaminen tarkoittaa toisen suunnistajan perässä kulkemista ja hänen navigointipäätöstensä hyödyntämistä oman karttasuunnistuksen sijaan. Tätä pidetään huonona urheiluhenkenä suunnistuksessa.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "perässä roikkuminen"
+    ],
+    "id": "henge"
+  },
+  {
+    "name": "N (naiset)",
+    "description": "N tarkoittaa naisia suunnistusluokkien nimissä, esimerkiksi N21E (naisten eliittisarja, 21 vuotta täyttäneet ja vanhemmat). Suomessa naisten luokista käytetään N-kirjainta (<i>naiset</i>). Skandinaviassa käytetään D-kirjainta (<i>Dame/Damer</i>).",
+    "tags": [],
+    "related": [
+      "H"
+    ],
+    "aliases": [
+      "D"
+    ],
+    "id": "D"
+  },
+  {
+    "name": "M (miehet)",
+    "description": "M tarkoittaa miehiä suunnistusluokkien nimissä, esimerkiksi M21E (miesten eliittisarja, 21 vuotta täyttäneet ja vanhemmat). Suomessa miesten luokista käytetään M-kirjainta (<i>miehet</i>). Skandinaviassa käytetään H-kirjainta (<i>Herre/Herrer</i>).",
+    "tags": [],
+    "related": [
+      "D"
+    ],
+    "aliases": [
+      "H"
+    ],
+    "id": "H"
+  },
+  {
+    "name": "O",
+    "description": "Suunnistajat rakastavat O-kirjainta ja käyttävät sitä aina kun mahdollista: o-kengät (<a href=\"/#suunnistuskengt\">suunnistuskengät</a>), o-harjoitus (suunnistusharjoitus), o-puku, o-laji ja niin edelleen. Se on lyhenne suunnistuksesta ja on laajalti käytössä suunnistuskulttuurissa.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "O"
+  },
+  {
+    "name": "suunnistuskengät",
+    "description": "Suunnistuskengissä on karkeat nastat ja usein myös piikkirimmellit pohjassa parhainta mahdollista pitoa varten liukkaalla maastolla, märillä juurilla ja jäisessä kelissä.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "o-kengät"
+    ],
+    "id": "orienteringssko"
+  },
+  {
+    "name": "johtolinja",
+    "description": "Johtolinja on helposti kartalta tunnistettava ja maastossa seurattava lineaarinen kohde — esimerkiksi puro, polku, pellon reuna tai aita. Johtolinja ohjaa turvallisesti paikasta toiseen ja voi toimia myös pysäyttävänä rajana: linja, jonka ylität väistämättä jos ylität maalisi.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "ledelinje"
+  },
+  {
+    "name": "georeferointi",
+    "description": "Suunnistuskartan georeferointi tarkoittaa sen sovittamista standardikoordinaatistoon (kuten WGS84). Tämä mahdollistaa GPS-kellon tai puhelimen tallentamien GPS-jälkien tarkan sijoittamisen kartalle kilpailun jälkeistä reittianalyysiä varten. Ilman georeferointia GPS-jälkeä ja karttaa ei voi luotettavasti yhdistää.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "georeferere"
+  },
+  {
+    "name": "Kjempesprekken",
+    "description": "Kjempesprekken on OSI Orienteering vuoden kohokohta — pitkä perinteiskilpailu, joka lähtee KSI-majan läheltä Nordmarkassa, Oslossa. 18 km, 12 km ja 6 km radat kiertävät kauniin Nordmarkan maisemissa. Kilpailun jälkeen seuraa seuran illallinen KSI-majalla. Nimi leikittelee norjan sanalla <i>sprekke</i> — hajoaminen (energian loppuminen kesken kilpailun).",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "Kjempesprekken"
+  },
+  {
+    "name": "Tiomila",
+    "description": "Yksi Skandinavian suurimmista ja arvostetuimmista suunnistusviestijuoksuista, joka järjestetään Ruotsissa joka kevät. Naiset kilpailevat päivällä (5 osuutta) ja miehet juoksevat yön läpi (10 osuutta).",
+    "tags": [
+      "viesti"
+    ],
+    "related": [
+      "Jukola",
+      "Night Hawk"
+    ],
+    "aliases": [],
+    "id": "Tiomila"
+  },
+  {
+    "name": "Jukola",
+    "description": "Jukola on yksi maailman suurimmista suunnistusviestijuoksuista, noin 15 000 osallistujalla. Se järjestetään Suomessa joka kesäkuussa. Naiset kilpailevat päivällä Venlojen viestin nimellä (4 osuutta) ja miehet juoksevat yön läpi (7 osuutta). Jukola on suomalaisen suunnistuksen vuoden suurin tapahtuma.",
+    "tags": [
+      "viesti"
+    ],
+    "related": [
+      "Tiomila",
+      "Night Hawk"
+    ],
+    "aliases": [
+      "Venlojen viesti"
+    ],
+    "id": "Jukola"
+  },
+  {
+    "name": "Night Hawk",
+    "description": "Night Hawk oli Norjan vastine Tiomilalle ja Jukolalle — suuri suunnistusviestijuoksu, jonka Tyrving IL järjesti elokuussa. Naisilla oli 6 osuutta ja miehillä 8 osuutta, ja noin puolet viestiä juostiin pimeässä. Viimeinen kilpailu järjestettiin vuonna 2023 ja se on sittemmin lopetettu.",
+    "tags": [
+      "viesti"
+    ],
+    "related": [
+      "Tiomila",
+      "Jukola"
+    ],
+    "aliases": [],
+    "id": "Night Hawk"
+  },
+  {
+    "name": "yösuunnistus",
+    "description": "Suunnistus pimeässä. Monet suunnistajat pitävät yösuunnistusta päiväsuunnistusta kiehtovampana — otsalampulla navigointi vaatii paljon enemmän keskittymistä ja karttakontaktia. Tarkan sijaintitietoisuuden merkitys korostuu, kun näkyvyys rajoittuu lampun valokeilaan. Rastin heijastavan merkin löytäminen pimeässä tuottaa syvää onnistumisen tunnetta.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "nattorientering"
+  },
+  {
+    "name": "keskeyttäminen",
+    "description": "Jos loukkaat itsesi tai eksyt toivottomasti, voit keskeyttää kilpailun. Löydä nopein turvallinen reitti takaisin <a href=\"/#kilpailukeskus\">kilpailukeskukseen</a>. On välttämätöntä ilmoittautua maaliin tai latausasemalle myös keskeyttäessä, jotta toimitsijat tietävät sinun olevan turvassa eivätkä käynnistä etsintäoperaatiota. Keskeyttäneet kirjataan tuloksiin DNF (Did Not Finish).",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "DNF"
+    ],
+    "id": "bryte"
+  },
+  {
+    "name": "kuntosarjat",
+    "description": "Kuntosarjat ovat luokkia, joihin voi ilmoittautua kilpailupäivänä paikan päällä ilman ennakkoilmoittautumista. Niissä ei yleensä ole ikä- tai sukupuolijakoa. Ne sopivat erinomaisesti aloittelijoille, ilmoittautumisajan ylittäneille sekä lapsiperheille, joilla on tarvetta joustavuuteen saapumisajan suhteen.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "avoin luokka",
+      "suoralähtö"
+    ],
+    "id": "direkteklasser"
+  },
+  {
+    "name": "tarkkuussuunnistus",
+    "description": "Tarkkuussuunnistus (pre-O) on IOF:n virallisesti tunnustama suunnistuksen muoto, joka on suunniteltu sekä liikuntarajoitteisille että muille osallistujille. Radat kulkevat pyörätuolille soveltuvilla poluilla ja teillä. Haaste on karttasuunnistuksen tarkkuudessa eikä juoksunopeudessa — jokaisen rastin kohdalla on useita merkkejä, ja kilpailijan tulee tunnistaa, mikä niistä (jos mikään) vastaa karttaa ja <a href=\"/#rastikuvaus\">rastikuvausta</a>. Joillakin rasteilla on vain yksi merkki, ja tehtävänä on päättää, mikä useista rastikuvauksista on oikea.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "pre-O"
+    ],
+    "id": "presisjonsorientering"
+  },
+  {
+    "name": "lasten radat",
+    "description": "Lasten radat on suunniteltu kaikkein pienimmille osallistujille. Ne ovat merkittyjä reittejä, joissa on hauskoja ja innostavia rasteja tavanomaisten suunnistusviirustien sijaan, painottaen iloa ja seikkailua tarkan karttasuunnistuksen sijaan. Kaikki maaliin saapuvat saavat yleensä palkinnon.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "lasten suunnistus"
+    ],
+    "id": "småtroll"
+  },
+  {
+    "name": "ekvidistanssi",
+    "description": "Ekvidistanssi on kahden vierekkäisen korkeuskäyrän (kartan ruskeisten viivojen) välinen korkeusero. Pienempi ekvidistanssi mahdollistaa tarkemman korkeusesityksen kartalla. Useimmissa suunnistuskartoissa ekvidistanssi on 5 metriä. Katso <a href=\"/#vahvistuskyr\">vahvistuskäyrä</a>.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "ekvidistanse"
+  },
+  {
+    "name": "vahvistuskäyrä",
+    "description": "Joka viides korkeuskäyrä on kartalla hieman paksumpi — tämä on vahvistuskäyrä. Vahvistuskäyrät helpottavat suurempien korkeuserojen nopeaa laskemista. 5 metrin <a href=\"/#ekvidistanssi\">ekvidistanssilla</a> jokainen vahvistuskäyrä edustaa 25 metrin korkeutta. Kolme vahvistuskäyrää sinun ja seuraavan rastisi välillä tarkoittaa 75 metrin nousua.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "indeksikäyrä"
+    ],
+    "id": "tellekurve"
+  },
+  {
+    "name": "OSI",
+    "description": "OSI on lyhenne nimestä Oslostudentenes Idrettsklubb (Oslon opiskelijoiden urheiluseura). Suunnistusosasto OSI Orientering järjestää kilpailuja ja harjoituksia Oslon seudulla. Tämä sanasto on OSI Orienteering -osaston luoma.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "Oslostudentenes Idrettsklubb",
+      "Oslostudentenes IK"
+    ],
+    "id": "OSI"
+  },
+  {
+    "name": "kiintorastit",
+    "description": "Kiintorastit ovat suunnistusratoja, joita voi suorittaa omaan tahtiin milloin tahansa kauden aikana. Ostat tai lataat kartan, johon rastit on merkitty; rastit pysyvät maastossa koko kesäkauden. Rasteilla on yleensä tunnuskoodi, jonka voi kirjata ylös.",
+    "tags": [],
+    "related": [],
+    "aliases": [
+      "viirisuunnistus"
+    ],
+    "id": "turorientering"
+  },
+  {
+    "name": "Stolpejakten",
+    "description": "Stolpejakten on ilmainen aktiviteetti, jossa etsitään osallistuviin kuntiin sijoitettuja pylväitä. Jokainen pylväs voidaan kirjata <a href=\"https://www.stolpejakten.no/#/about\">Stolpejakten-sovelluksessa</a> QR-koodilla tai manuaalisesti syötetyllä koodilla. Ladattavia karttoja on saatavilla sovelluksesta. Stolpejakten muistuttaa <a href=\"#kiintorastit\">kiintorasteja</a>, mutta sijoittuu tyypillisesti enemmän kaupunkialueille. Aktiviteetti on erityisen suosittu Norjassa ja Ruotsissa.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "Stolpejakten"
+  },
+  {
+    "name": "nollaus",
+    "description": "Nollaus pyyhkii aiemman kilpailun tiedot pois brikistä ennen uutta kilpailua. Tämä on tehtävä erillisellä nollausasemalla ennen lähtöä. Nollauksen unohtaminen voi johtaa virheellisiin ajanottotietoihin ja diskvalifikaatioon.",
+    "tags": [
+      "ajanotto"
+    ],
+    "related": [],
+    "aliases": [
+      "tyhjennys"
+    ],
+    "id": "nulle"
+  },
+  {
+    "name": "Livelox",
+    "description": "<a href=\"https://www.livelox.com/\">Livelox</a> on alusta suunnistusreittien analysointiin ja jakamiseen. Kilpailun järjestäjät lataavat ratakartan etukäteen; kilpailun jälkeen osallistujat voivat ladata GPS-jälkensä kellosta tai puhelimesta nähdäkseen reittinsä kartalla ja verrata sitä muihin juoksijoihin. Muita vastaavia palveluja ovat <a href=\"http://3drerun.worldofo.com/\">3D Rerun</a> ja <a href=\"http://www.opath.se/\">OPath</a>, mutta Livelox on laajimmin käytetty.",
+    "tags": [],
+    "related": [],
+    "aliases": [],
+    "id": "Livelox"
+  },
+  {
+    "name": "pistesuunnistus",
+    "description": "Pistesuunnistus (score-O) on harjoitusmuoto tai kilpailu, jossa tavoitteena on kerätä mahdollisimman monta rastia tietyssä aikarajassa (esim. 30–60 minuuttia). Toisin kuin tavallisessa suunnistuksessa, juoksija valitsee itse rastien järjestyksen, mikä edellyttää hyvää suunnittelua ja tehokasta reittivalintataktiikkaa.",
+    "tags": [],
+    "related": [
+      "orienteringspost"
+    ],
+    "aliases": [
+      "score-O",
+      "hajontarastit"
+    ],
+    "id": "postplukk"
+  },
+  {
+    "name": "rastiympyrä",
+    "description": "Rastiympyrä on suunnistuskartalle painettu ympyrä, joka merkitsee rastin tarkan sijainnin. Ympyrä on keskitetty tarkasti löydettävälle maastokohteelle. <i>Katso myös <a href=\"/#rastikuvaus\">rastikuvaus</a></i>.",
+    "tags": [],
+    "related": [
+      "kart",
+      "orienteringspost",
+      "postbeskrivelse"
+    ],
+    "aliases": [],
+    "id": "ringen"
+  },
+  {
+    "name": "lähtörasti",
+    "description": "Lähtörasti on radan ensimmäinen rasti. Suuremmissa kilpailuissa se sijaitsee jonkin matkan päässä varsinaisesta lähtöpaikasta, ja reitti sinne on merkitty nauhoin, jotta juoksijat eivät tarvitse navigoida ensimmäistä osuutta. Pienemmissä kilpailuissa lähtö ja lähtörasti ovat yleensä samassa paikassa. Lähtörasti merkitään kolmiolla kartalla.",
+    "tags": [],
+    "related": [
+      "orienteringspost"
+    ],
+    "aliases": [],
+    "id": "startpost"
+  },
+  {
+    "name": "leimasin",
+    "description": "Leimasin on suunnistuksen perinteinen manuaalinen leimausväline ennen elektronista ajanottoa. Se tekee leimauskortille ainutlaatuisen reikäkuvion, joka todistaa kilpailijan käyneen rastilla. Leimaimia näkee nykyään harvoin kilpailuissa. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "tags": [
+      "ajanotto"
+    ],
+    "related": [
+      "tidtaking",
+      "orienteringspost"
+    ],
+    "aliases": [],
+    "id": "klippetang"
+  },
+  {
+    "name": "Sportiduino",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> on avoimen lähdekoodin elektroninen ajanottojärjestelmä suunnistukseen, joka tarjoaa edullisemman vaihtoehdon <a href=\"/#sportident\">SPORTIdentille</a> ja <a href=\"/#emit\">EMITille</a>. Se perustuu Arduino-alustaan; pystytys vaatii merkittävästi aikaa ja vaivaa, koska rastit ja brikkien lukijalaite on rakennettava komponenteista. Toinen avoimen lähdekoodin vaihtoehto on <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a>.",
+    "tags": [
+      "ajanotto"
+    ],
+    "related": [
+      "tidtaking",
+      "SPORTIdent",
+      "EMIT"
+    ],
+    "aliases": [],
+    "id": "Sportiduino"
+  },
+  {
+    "name": "SIAC",
+    "description": "SIAC (SPORTIdent Air+ Card) on SPORTIdentin kosketukseton brikki. Toisin kuin tavallinen SI-brikki, SIAC:ia ei tarvitse laittaa fyysisesti leimasimeen — se rekisteröityy automaattisesti pidettäessä riittävän lähellä kontrolliyksikköä, ja piippaa ja välkkyy vahvistaakseen leimauksen. SIAC vaatii Air+-yksiköillä varustetut rastit. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "tags": [
+      "ajanotto"
+    ],
+    "related": [
+      "SPORTIdent",
+      "emiTag",
+      "tidtaking"
+    ],
+    "aliases": [
+      "SPORTIdent Air+ Card",
+      "SI Air+"
+    ],
+    "id": "SIAC"
+  },
+  {
+    "name": "emiTag",
+    "description": "emiTag on EMITin kosketukseton brikki — SPORTIdentin <a href=\"/#siac\">SIAC</a>in vastine. Se rekisteröityy automaattisesti ohitettaessa lähellä rastin leimasinta ilman fyysistä kontaktia. Käytetään EMIT-järjestelmällä toimivissa kilpailuissa. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "tags": [
+      "ajanotto"
+    ],
+    "related": [
+      "EMIT",
+      "SIAC",
+      "SPORTIdent",
+      "tidtaking"
+    ],
+    "aliases": [],
+    "id": "emiTag"
+  },
+  {
+    "name": "Huichang",
+    "description": "Huichang on kiinalainen suunnistuksen elektroninen ajanottojärjestelmä, jonka valmistaa Beijing Huichang Sports Technology. Se on hallitseva ajanottojärjestelmä kiinalaisessa suunnistuksessa ja laajasti käytössä Aasiassa. Se toimii samoilla periaatteilla kuin <a href=\"/#sportident\">SPORTIdent</a> ja <a href=\"/#emit\">EMIT</a>. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "tags": [
+      "ajanotto"
+    ],
+    "related": [
+      "SPORTIdent",
+      "EMIT",
+      "SFR",
+      "tidtaking"
+    ],
+    "aliases": [],
+    "id": "Huichang"
+  }
+]

--- a/resources/orienteering_dictionary_fi.json
+++ b/resources/orienteering_dictionary_fi.json
@@ -46,7 +46,7 @@
   },
   {
     "name": "EMIT",
-    "description": "EMIT on norjalaisen EMIT-yrityksen valmistama elektroninen ajanottojärjestelmä suunnistukseen. Se on hallitseva järjestelmä Suomessa ja Norjassa. Kansainvälisesti <a href=\"/#sportident\">SPORTIdent</a> on yleisempi standardi. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "description": "EMIT on norjalaisen EMIT-yrityksen valmistama elektroninen ajanottojärjestelmä suunnistukseen. Se on hallitseva järjestelmä Suomessa ja Norjassa. Kansainvälisesti <a href=\"/fi/#sportident\">SPORTIdent</a> on yleisempi standardi. <i>Katso <a href=\"/fi/#ajanotto\">ajanotto</a></i>.",
     "tags": [
       "ajanotto"
     ],
@@ -60,7 +60,7 @@
   },
   {
     "name": "ajanotto",
-    "description": "Elektroninen ajanotto suunnistuksessa perustuu henkilökohtaiseen brikki-siruun, joka on rekisteröity kullekin kilpailijalle. Kun juoksija saapuu rastille, hän leimaa brikinsä rastin leimasimeen, jolloin käynti rekisteröityy. Maalissa brikki luetaan ja saadaan kokonaisaika sekä välitulokset rastien väliltä. Yleisimmät järjestelmät ovat <a href=\"/#emit\">EMIT</a> ja <a href=\"/#sportident\">SPORTIdent</a>.",
+    "description": "Elektroninen ajanotto suunnistuksessa perustuu henkilökohtaiseen brikki-siruun, joka on rekisteröity kullekin kilpailijalle. Kun juoksija saapuu rastille, hän leimaa brikinsä rastin leimasimeen, jolloin käynti rekisteröityy. Maalissa brikki luetaan ja saadaan kokonaisaika sekä välitulokset rastien väliltä. Yleisimmät järjestelmät ovat <a href=\"/fi/#emit\">EMIT</a> ja <a href=\"/fi/#sportident\">SPORTIdent</a>.",
     "tags": [
       "ajanotto"
     ],
@@ -74,7 +74,7 @@
   },
   {
     "name": "haarukointi",
-    "description": "Haarukoinnilla estetään kilpailijoita <a href=\"/#seuraaminen\">seuraamasta</a> toisiaan radalla. Saman sarjan juoksijat saavat hieman toisistaan poikkeavat radat — useimmat rastit ovat yhteisiä, mutta tietyissä kohdissa eri juoksijat käyvät eri rasteilla. Juoksijoiden on navigoitava huolellisesti leimatakseen oikean rastin; väärän rastin leimaaminen johtaa diskvalifikaatioon.",
+    "description": "Haarukoinnilla estetään kilpailijoita <a href=\"/fi/#seuraaminen\">seuraamasta</a> toisiaan radalla. Saman sarjan juoksijat saavat hieman toisistaan poikkeavat radat — useimmat rastit ovat yhteisiä, mutta tietyissä kohdissa eri juoksijat käyvät eri rasteilla. Juoksijoiden on navigoitava huolellisesti leimatakseen oikean rastin; väärän rastin leimaaminen johtaa diskvalifikaatioon.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -92,7 +92,7 @@
   },
   {
     "name": "SPORTIdent",
-    "description": "<a href=\"https://www.sportident.com/\">SPORTIdent</a> on kansainvälisesti eniten käytetty elektroninen ajanottojärjestelmä suunnistuksessa. Henkilökohtaista brikki-sirua kutsutaan SI-brikki:ksi. SPORTIdent on käytössä MM-kilpailuissa ja hallitseva järjestelmä Ruotsissa sekä suurimmassa osassa Eurooppaa. Suomessa ja Norjassa <a href=\"/#emit\">EMIT</a> on yleisempi. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "description": "<a href=\"https://www.sportident.com/\">SPORTIdent</a> on kansainvälisesti eniten käytetty elektroninen ajanottojärjestelmä suunnistuksessa. Henkilökohtaista brikki-sirua kutsutaan SI-brikki:ksi. SPORTIdent on käytössä MM-kilpailuissa ja hallitseva järjestelmä Ruotsissa sekä suurimmassa osassa Eurooppaa. Suomessa ja Norjassa <a href=\"/fi/#emit\">EMIT</a> on yleisempi. <i>Katso <a href=\"/fi/#ajanotto\">ajanotto</a></i>.",
     "tags": [
       "ajanotto"
     ],
@@ -139,7 +139,7 @@
   },
   {
     "name": "kartta",
-    "description": "Suunnistuskartta esittää maaston pelkistetyssä muodossa ja on tärkein väline rastien välillä navigointiin. Kartassa on runsaasti symboleja: korkeuskäyrät kuvaavat korkeuseroja, mustat pisteet tarkoittavat kiviä, siniset alueet vettä ja niin edelleen. Karttoja painetaan eri <i><a href=\"/#mittakaava\">mittakaavoissa</a></i>, tyypillisesti 1:5000 sprinttisuunnistuksessa ja 1:10000 metsäsuunnistuksessa.",
+    "description": "Suunnistuskartta esittää maaston pelkistetyssä muodossa ja on tärkein väline rastien välillä navigointiin. Kartassa on runsaasti symboleja: korkeuskäyrät kuvaavat korkeuseroja, mustat pisteet tarkoittavat kiviä, siniset alueet vettä ja niin edelleen. Karttoja painetaan eri <i><a href=\"/fi/#mittakaava\">mittakaavoissa</a></i>, tyypillisesti 1:5000 sprinttisuunnistuksessa ja 1:10000 metsäsuunnistuksessa.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -157,7 +157,7 @@
   },
   {
     "name": "kompassi",
-    "description": "Kompassi osoittaa pohjoisen (ja siten etelän, idän ja lännen) suunnan. Suunnistaja käyttää kompassia pitääkseen suunnan seuraavalle <i><a href=\"/#rasti\">rastille</a></i> tai asettaakseen kartan — kääntääkseen sen vastaamaan ympäröivää maastoa.",
+    "description": "Kompassi osoittaa pohjoisen (ja siten etelän, idän ja lännen) suunnan. Suunnistaja käyttää kompassia pitääkseen suunnan seuraavalle <i><a href=\"/fi/#rasti\">rastille</a></i> tai asettaakseen kartan — kääntääkseen sen vastaamaan ympäröivää maastoa.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -165,7 +165,7 @@
   },
   {
     "name": "rasti",
-    "description": "Suunnistusrasti (kutsutaan myös postiksi tai merkiksi) koostuu oranssi-valkoisesta viirustasta ja siihen kiinnitetystä leimasimesta, jolla kilpailijan käynti rastilla rekisteröidään. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "description": "Suunnistusrasti (kutsutaan myös postiksi tai merkiksi) koostuu oranssi-valkoisesta viirustasta ja siihen kiinnitetystä leimasimesta, jolla kilpailijan käynti rastilla rekisteröidään. <i>Katso <a href=\"/fi/#ajanotto\">ajanotto</a></i>.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -176,7 +176,7 @@
   },
   {
     "name": "peukalokompassi",
-    "description": "Peukalokompassi kiinnitetään peukaloon, jolloin kartta ja kompassi voidaan pitää yhtenä kokonaisuutena — suosituin kompassityyppi suunnistajien keskuudessa. Perinteisiä levykompasseja käytetään myös, mutta ne ovat harvinaisempia kilpailuissa. <i>Katso <a href=\"/#kompassi\">kompassi</a></i>.",
+    "description": "Peukalokompassi kiinnitetään peukaloon, jolloin kartta ja kompassi voidaan pitää yhtenä kokonaisuutena — suosituin kompassityyppi suunnistajien keskuudessa. Perinteisiä levykompasseja käytetään myös, mutta ne ovat harvinaisempia kilpailuissa. <i>Katso <a href=\"/fi/#kompassi\">kompassi</a></i>.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -184,7 +184,7 @@
   },
   {
     "name": "A-taso",
-    "description": "A-taso on teknisesti vaativin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä. Kaikkien suunnistustekniikoiden hallitseminen on tarpeen. <i>Katso <a href=\"/#vaikeusaste\">vaikeusaste</a></i>.",
+    "description": "A-taso on teknisesti vaativin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä. Kaikkien suunnistustekniikoiden hallitseminen on tarpeen. <i>Katso <a href=\"/fi/#vaikeusaste\">vaikeusaste</a></i>.",
     "tags": [],
     "related": [
       "B-nivå",
@@ -196,7 +196,7 @@
   },
   {
     "name": "B-taso",
-    "description": "B-taso on toiseksi vaativin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä. B-radat edellyttävät lyhyttä hienosuunnistusta rastille sekä korkeuskäyrien hyvää ymmärtämistä. <i>Katso <a href=\"/#vaikeusaste\">vaikeusaste</a></i>.",
+    "description": "B-taso on toiseksi vaativin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä. B-radat edellyttävät lyhyttä hienosuunnistusta rastille sekä korkeuskäyrien hyvää ymmärtämistä. <i>Katso <a href=\"/fi/#vaikeusaste\">vaikeusaste</a></i>.",
     "tags": [],
     "related": [
       "A-nivå",
@@ -208,7 +208,7 @@
   },
   {
     "name": "C-taso",
-    "description": "C-taso on toiseksi helpoin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä. C-radat seuraavat pääosin <a href=\"/#johtolinja\">johtolinjoja</a>, mutta juoksijoiden odotetaan poikkeavan niiltä tietyissä kohdissa. Reitinvalintamahdollisuuksia voi esiintyä. <i>Katso <a href=\"/#vaikeusaste\">vaikeusaste</a></i>.",
+    "description": "C-taso on toiseksi helpoin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä. C-radat seuraavat pääosin <a href=\"/fi/#johtolinja\">johtolinjoja</a>, mutta juoksijoiden odotetaan poikkeavan niiltä tietyissä kohdissa. Reitinvalintamahdollisuuksia voi esiintyä. <i>Katso <a href=\"/fi/#vaikeusaste\">vaikeusaste</a></i>.",
     "tags": [],
     "related": [
       "A-nivå",
@@ -220,7 +220,7 @@
   },
   {
     "name": "N-taso",
-    "description": "N-taso on helpoin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä, tarkoitettu aloittelijoille. N-radat seuraavat yhtenäisiä <a href=\"/#johtolinja\">johtolinjoja</a>, kuten polkuja, uria, puroja ja aitoja, ja kaikki rastit näkyvät johtolinjoilta. <i>Katso <a href=\"/#vaikeusaste\">vaikeusaste</a></i>.",
+    "description": "N-taso on helpoin ratavaikeusaste pohjoismaisessa luokittelujärjestelmässä, tarkoitettu aloittelijoille. N-radat seuraavat yhtenäisiä <a href=\"/fi/#johtolinja\">johtolinjoja</a>, kuten polkuja, uria, puroja ja aitoja, ja kaikki rastit näkyvät johtolinjoilta. <i>Katso <a href=\"/fi/#vaikeusaste\">vaikeusaste</a></i>.",
     "tags": [],
     "related": [
       "A-nivå",
@@ -232,7 +232,7 @@
   },
   {
     "name": "vaikeusaste",
-    "description": "Pohjoismaisessa luokittelujärjestelmässä radat jaetaan neljään vaikeusasteeseen: <a href=\"/#a-taso\">A</a>, <a href=\"/#b-taso\">B</a>, <a href=\"/#c-taso\">C</a> ja <a href=\"/#n-taso\">N</a>, joista A on vaikein ja N on aloittelijoille tarkoitettu. Tätä järjestelmää käytetään Suomessa, Norjassa ja Ruotsissa. Muissa maissa käytetään erilaisia väri- tai numeropohjaisia järjestelmiä.",
+    "description": "Pohjoismaisessa luokittelujärjestelmässä radat jaetaan neljään vaikeusasteeseen: <a href=\"/fi/#a-taso\">A</a>, <a href=\"/fi/#b-taso\">B</a>, <a href=\"/fi/#c-taso\">C</a> ja <a href=\"/fi/#n-taso\">N</a>, joista A on vaikein ja N on aloittelijoille tarkoitettu. Tätä järjestelmää käytetään Suomessa, Norjassa ja Ruotsissa. Muissa maissa käytetään erilaisia väri- tai numeropohjaisia järjestelmiä.",
     "tags": [],
     "related": [
       "A-nivå",
@@ -279,7 +279,7 @@
   },
   {
     "name": "O",
-    "description": "Suunnistajat rakastavat O-kirjainta ja käyttävät sitä aina kun mahdollista: o-kengät (<a href=\"/#suunnistuskengt\">suunnistuskengät</a>), o-harjoitus (suunnistusharjoitus), o-puku, o-laji ja niin edelleen. Se on lyhenne suunnistuksesta ja on laajalti käytössä suunnistuskulttuurissa.",
+    "description": "Suunnistajat rakastavat O-kirjainta ja käyttävät sitä aina kun mahdollista: o-kengät (<a href=\"/fi/#suunnistuskengt\">suunnistuskengät</a>), o-harjoitus (suunnistusharjoitus), o-puku, o-laji ja niin edelleen. Se on lyhenne suunnistuksesta ja on laajalti käytössä suunnistuskulttuurissa.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -313,7 +313,7 @@
   },
   {
     "name": "Kjempesprekken",
-    "description": "Kjempesprekken on OSI Orienteering vuoden kohokohta — pitkä perinteiskilpailu, joka lähtee KSI-majan läheltä Nordmarkassa, Oslossa. 18 km, 12 km ja 6 km radat kiertävät kauniin Nordmarkan maisemissa. Kilpailun jälkeen seuraa seuran illallinen KSI-majalla. Nimi leikittelee norjan sanalla <i>sprekke</i> — hajoaminen (energian loppuminen kesken kilpailun).",
+    "description": "Kjempesprekken on OSI Orienteering vuoden kohokohta — pitkä perinteiskilpailu, joka lähtee KSI-majan läheltä Nordmarkassa, Oslossa. Aluksi oli vain 30 km ja 18 km, mutta myöhemmin lisättiin 12 km ja 6 km, ja 30 km poistui. Nykyään on 18 km, 12 km ja 6 km radat kauniin Nordmarkan maisemissa. Kilpailun jälkeen seuraa seuran illallinen KSI-majalla. Nimi leikittelee norjan sanalla <i>sprekke</i> — hajoaminen (energian loppuminen kesken kilpailun).",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -370,7 +370,7 @@
   },
   {
     "name": "keskeyttäminen",
-    "description": "Jos loukkaat itsesi tai eksyt toivottomasti, voit keskeyttää kilpailun. Löydä nopein turvallinen reitti takaisin <a href=\"/#kilpailukeskus\">kilpailukeskukseen</a>. On välttämätöntä ilmoittautua maaliin tai latausasemalle myös keskeyttäessä, jotta toimitsijat tietävät sinun olevan turvassa eivätkä käynnistä etsintäoperaatiota. Keskeyttäneet kirjataan tuloksiin DNF (Did Not Finish).",
+    "description": "Jos loukkaat itsesi tai eksyt toivottomasti, voit keskeyttää kilpailun. Löydä nopein turvallinen reitti takaisin <a href=\"/fi/#kilpailukeskus\">kilpailukeskukseen</a>. On välttämätöntä ilmoittautua maaliin tai latausasemalle myös keskeyttäessä, jotta toimitsijat tietävät sinun olevan turvassa eivätkä käynnistä etsintäoperaatiota. Keskeyttäneet kirjataan tuloksiin DNF (Did Not Finish).",
     "tags": [],
     "related": [],
     "aliases": [
@@ -391,7 +391,7 @@
   },
   {
     "name": "tarkkuussuunnistus",
-    "description": "Tarkkuussuunnistus (pre-O) on IOF:n virallisesti tunnustama suunnistuksen muoto, joka on suunniteltu sekä liikuntarajoitteisille että muille osallistujille. Radat kulkevat pyörätuolille soveltuvilla poluilla ja teillä. Haaste on karttasuunnistuksen tarkkuudessa eikä juoksunopeudessa — jokaisen rastin kohdalla on useita merkkejä, ja kilpailijan tulee tunnistaa, mikä niistä (jos mikään) vastaa karttaa ja <a href=\"/#rastikuvaus\">rastikuvausta</a>. Joillakin rasteilla on vain yksi merkki, ja tehtävänä on päättää, mikä useista rastikuvauksista on oikea.",
+    "description": "Tarkkuussuunnistus (pre-O) on IOF:n virallisesti tunnustama suunnistuksen muoto, joka on suunniteltu sekä liikuntarajoitteisille että muille osallistujille. Radat kulkevat pyörätuolille soveltuvilla poluilla ja teillä. Haaste on karttasuunnistuksen tarkkuudessa eikä juoksunopeudessa — jokaisen rastin kohdalla on useita merkkejä, ja kilpailijan tulee tunnistaa, mikä niistä (jos mikään) vastaa karttaa ja <a href=\"/fi/#rastikuvaus\">rastikuvausta</a>. Joillakin rasteilla on vain yksi merkki, ja tehtävänä on päättää, mikä useista rastikuvauksista on oikea.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -401,7 +401,7 @@
   },
   {
     "name": "lasten radat",
-    "description": "Lasten radat on suunniteltu kaikkein pienimmille osallistujille. Ne ovat merkittyjä reittejä, joissa on hauskoja ja innostavia rasteja tavanomaisten suunnistusviirustien sijaan, painottaen iloa ja seikkailua tarkan karttasuunnistuksen sijaan. Kaikki maaliin saapuvat saavat yleensä palkinnon.",
+    "description": "Lasten radat on suunniteltu kaikkein pienimmille osallistujille. Ne ovat merkittyjä reittejä, joissa on hauskoja ja innostavia rasteja tavanomaisten suunnistusviirustien sijaan — radat voivat olla myös estehtanatyyppisiä. Pääpaino on iloissa ja seikkailussa tarkan karttasuunnistuksen sijaan. Kaikki maaliin saapuvat saavat yleensä palkinnon.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -411,7 +411,7 @@
   },
   {
     "name": "ekvidistanssi",
-    "description": "Ekvidistanssi on kahden vierekkäisen korkeuskäyrän (kartan ruskeisten viivojen) välinen korkeusero. Pienempi ekvidistanssi mahdollistaa tarkemman korkeusesityksen kartalla. Useimmissa suunnistuskartoissa ekvidistanssi on 5 metriä. Katso <a href=\"/#vahvistuskyr\">vahvistuskäyrä</a>.",
+    "description": "Ekvidistanssi on kahden vierekkäisen korkeuskäyrän (kartan ruskeisten viivojen) välinen korkeusero. Pienempi ekvidistanssi mahdollistaa tarkemman korkeusesityksen kartalla. Useimmissa suunnistuskartoissa ekvidistanssi on 5 metriä. Katso <a href=\"/fi/#vahvistuskyr\">vahvistuskäyrä</a>.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -419,7 +419,7 @@
   },
   {
     "name": "vahvistuskäyrä",
-    "description": "Joka viides korkeuskäyrä on kartalla hieman paksumpi — tämä on vahvistuskäyrä. Vahvistuskäyrät helpottavat suurempien korkeuserojen nopeaa laskemista. 5 metrin <a href=\"/#ekvidistanssi\">ekvidistanssilla</a> jokainen vahvistuskäyrä edustaa 25 metrin korkeutta. Kolme vahvistuskäyrää sinun ja seuraavan rastisi välillä tarkoittaa 75 metrin nousua.",
+    "description": "Joka viides korkeuskäyrä on kartalla hieman paksumpi — tämä on vahvistuskäyrä. Vahvistuskäyrät helpottavat suurempien korkeuserojen nopeaa laskemista. 5 metrin <a href=\"/fi/#ekvidistanssi\">ekvidistanssilla</a> jokainen vahvistuskäyrä edustaa 25 metrin korkeutta. Kolme vahvistuskäyrää sinun ja seuraavan rastisi välillä tarkoittaa 75 metrin nousua.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -458,7 +458,7 @@
   },
   {
     "name": "nollaus",
-    "description": "Nollaus pyyhkii aiemman kilpailun tiedot pois brikistä ennen uutta kilpailua. Tämä on tehtävä erillisellä nollausasemalla ennen lähtöä. Nollauksen unohtaminen voi johtaa virheellisiin ajanottotietoihin ja diskvalifikaatioon.",
+    "description": "Nollaus pyyhkii aiemman kilpailun tiedot pois brikistä ennen uutta kilpailua. Tämä on tehtävä erillisellä nollausasemalla ennen lähtöä. Nollauksen unohtaminen tarkoittaa, ettei kilpailija saa oikeaa aikaa, ja johtaa diskvalifikaatioon.",
     "tags": [
       "ajanotto"
     ],
@@ -491,7 +491,7 @@
   },
   {
     "name": "rastiympyrä",
-    "description": "Rastiympyrä on suunnistuskartalle painettu ympyrä, joka merkitsee rastin tarkan sijainnin. Ympyrä on keskitetty tarkasti löydettävälle maastokohteelle. <i>Katso myös <a href=\"/#rastikuvaus\">rastikuvaus</a></i>.",
+    "description": "Rastiympyrä on suunnistuskartalle painettu ympyrä, joka merkitsee rastin tarkan sijainnin. Ympyrä on keskitetty tarkasti löydettävälle maastokohteelle. <i>Katso myös <a href=\"/fi/#rastikuvaus\">rastikuvaus</a></i>.",
     "tags": [],
     "related": [
       "kart",
@@ -513,7 +513,7 @@
   },
   {
     "name": "leimasin",
-    "description": "Leimasin on suunnistuksen perinteinen manuaalinen leimausväline ennen elektronista ajanottoa. Se tekee leimauskortille ainutlaatuisen reikäkuvion, joka todistaa kilpailijan käyneen rastilla. Leimaimia näkee nykyään harvoin kilpailuissa. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "description": "Leimasin on suunnistuksen perinteinen manuaalinen leimausväline ennen elektronista ajanottoa. Se tekee leimauskortille ainutlaatuisen reikäkuvion, joka todistaa kilpailijan käyneen rastilla. Leimaimia näkee nykyään harvoin kilpailuissa. <i>Katso <a href=\"/fi/#ajanotto\">ajanotto</a></i>.",
     "tags": [
       "ajanotto"
     ],
@@ -526,7 +526,7 @@
   },
   {
     "name": "Sportiduino",
-    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> on avoimen lähdekoodin elektroninen ajanottojärjestelmä suunnistukseen, joka tarjoaa edullisemman vaihtoehdon <a href=\"/#sportident\">SPORTIdentille</a> ja <a href=\"/#emit\">EMITille</a>. Se perustuu Arduino-alustaan; pystytys vaatii merkittävästi aikaa ja vaivaa, koska rastit ja brikkien lukijalaite on rakennettava komponenteista. Toinen avoimen lähdekoodin vaihtoehto on <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a>.",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> on avoimen lähdekoodin elektroninen ajanottojärjestelmä suunnistukseen, joka tarjoaa edullisemman vaihtoehdon <a href=\"/fi/#sportident\">SPORTIdentille</a> ja <a href=\"/fi/#emit\">EMITille</a>. Se perustuu Arduino-alustaan; pystytys vaatii merkittävästi aikaa ja vaivaa, koska rastit ja brikkien lukijalaite on rakennettava komponenteista. Toinen avoimen lähdekoodin vaihtoehto on <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a>.",
     "tags": [
       "ajanotto"
     ],
@@ -540,7 +540,7 @@
   },
   {
     "name": "SIAC",
-    "description": "SIAC (SPORTIdent Air+ Card) on SPORTIdentin kosketukseton brikki. Toisin kuin tavallinen SI-brikki, SIAC:ia ei tarvitse laittaa fyysisesti leimasimeen — se rekisteröityy automaattisesti pidettäessä riittävän lähellä kontrolliyksikköä, ja piippaa ja välkkyy vahvistaakseen leimauksen. SIAC vaatii Air+-yksiköillä varustetut rastit. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "description": "SIAC (SPORTIdent Air+ Card) on SPORTIdentin kosketukseton brikki. Toisin kuin tavallinen SI-brikki, SIAC:ia ei tarvitse laittaa fyysisesti leimasimeen — se rekisteröityy automaattisesti pidettäessä riittävän lähellä kontrolliyksikköä, ja piippaa ja välkkyy vahvistaakseen leimauksen. SIAC vaatii Air+-yksiköillä varustetut rastit. <i>Katso <a href=\"/fi/#ajanotto\">ajanotto</a></i>.",
     "tags": [
       "ajanotto"
     ],
@@ -557,7 +557,7 @@
   },
   {
     "name": "emiTag",
-    "description": "emiTag on EMITin kosketukseton brikki — SPORTIdentin <a href=\"/#siac\">SIAC</a>in vastine. Se rekisteröityy automaattisesti ohitettaessa lähellä rastin leimasinta ilman fyysistä kontaktia. Käytetään EMIT-järjestelmällä toimivissa kilpailuissa. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "description": "emiTag on EMITin kosketukseton brikki — SPORTIdentin <a href=\"/fi/#siac\">SIAC</a>in vastine. Se rekisteröityy automaattisesti ohitettaessa lähellä rastin leimasinta ilman fyysistä kontaktia. Käytetään EMIT-järjestelmällä toimivissa kilpailuissa. <i>Katso <a href=\"/fi/#ajanotto\">ajanotto</a></i>.",
     "tags": [
       "ajanotto"
     ],
@@ -572,7 +572,7 @@
   },
   {
     "name": "Huichang",
-    "description": "Huichang on kiinalainen suunnistuksen elektroninen ajanottojärjestelmä, jonka valmistaa Beijing Huichang Sports Technology. Se on hallitseva ajanottojärjestelmä kiinalaisessa suunnistuksessa ja laajasti käytössä Aasiassa. Se toimii samoilla periaatteilla kuin <a href=\"/#sportident\">SPORTIdent</a> ja <a href=\"/#emit\">EMIT</a>. <i>Katso <a href=\"/#ajanotto\">ajanotto</a></i>.",
+    "description": "Huichang on kiinalainen suunnistuksen elektroninen ajanottojärjestelmä, jonka valmistaa Beijing Huichang Sports Technology. Se on hallitseva ajanottojärjestelmä kiinalaisessa suunnistuksessa ja laajasti käytössä Aasiassa. Se toimii samoilla periaatteilla kuin <a href=\"/fi/#sportident\">SPORTIdent</a> ja <a href=\"/fi/#emit\">EMIT</a>. <i>Katso <a href=\"/fi/#ajanotto\">ajanotto</a></i>.",
     "tags": [
       "ajanotto"
     ],

--- a/resources/orienteering_dictionary_sv.json
+++ b/resources/orienteering_dictionary_sv.json
@@ -45,7 +45,7 @@
   },
   {
     "name": "EMIT",
-    "description": "EMIT är ett elektroniskt tidtagningssystem för orientering tillverkat av det norska företaget EMIT. Det är det dominerande systemet i norsk och finsk orientering. I Sverige och internationellt används <a href=\"/#sportident\">SPORTIdent</a> som standard. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "description": "EMIT är ett elektroniskt tidtagningssystem för orientering tillverkat av det norska företaget EMIT. Det är det dominerande systemet i norsk och finsk orientering. I Sverige och internationellt används <a href=\"/sv/#sportident\">SPORTIdent</a> som standard. <i>Se <a href=\"/sv/#tidtagning\">tidtagning</a></i>.",
     "tags": [
       "tidtagning"
     ],
@@ -73,7 +73,7 @@
   },
   {
     "name": "gaffling",
-    "description": "Gaffling används för att förhindra att tävlande hänger efter varandra (<a href=\"/#hnga\">se hänga</a>). Löpare i samma klass får banor som skiljer sig lite åt — de flesta kontroller är gemensamma, men vid vissa punkter besöker olika löpare kontroller på lite olika ställen innan de möts igen på nästa gemensamma kontroll.",
+    "description": "Gaffling används för att förhindra att tävlande hänger efter varandra (<a href=\"/sv/#hnga\">se hänga</a>). Löpare i samma klass får banor som skiljer sig lite åt — de flesta kontroller är gemensamma, men vid vissa punkter besöker olika löpare kontroller på lite olika ställen innan de möts igen på nästa gemensamma kontroll.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -91,7 +91,7 @@
   },
   {
     "name": "SPORTIdent",
-    "description": "<a href=\"https://www.sportident.com/\">SPORTIdent</a> är det dominerande elektroniska tidtagningssystemet inom orientering i Sverige och internationellt. Den personliga brickan kallas SI-bricka. SPORTIdent är standard vid VM och används vid de allra flesta tävlingar i Sverige. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "description": "<a href=\"https://www.sportident.com/\">SPORTIdent</a> är det dominerande elektroniska tidtagningssystemet inom orientering i Sverige och internationellt. Den personliga brickan kallas SI-bricka. SPORTIdent är standard vid VM och används vid de allra flesta tävlingar i Sverige. <i>Se <a href=\"/sv/#tidtagning\">tidtagning</a></i>.",
     "tags": [
       "tidtagning"
     ],
@@ -136,7 +136,7 @@
   },
   {
     "name": "karta",
-    "description": "En orienteringskarta visar terrängen i förenklat format och är löparens viktigaste verktyg för att navigera mellan kontrollerna. Kartan innehåller många symboler: höjdkurvor visar höjdförhållanden, svarta prickar markerar stenar, blå ytor visar vatten och så vidare. Kartor trycks i olika <i><a href=\"/#skala\">skalor</a></i>, vanligen 1:7 500 eller 1:10 000 för tävlingsorientering och 1:15 000 för långdistans.",
+    "description": "En orienteringskarta visar terrängen i förenklat format och är löparens viktigaste verktyg för att navigera mellan kontrollerna. Kartan innehåller många symboler: höjdkurvor visar höjdförhållanden, svarta prickar markerar stenar, blå ytor visar vatten och så vidare. Kartor trycks i olika <i><a href=\"/sv/#skala\">skalor</a></i>, vanligen 1:7 500 eller 1:10 000 för tävlingsorientering och 1:15 000 för långdistans.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -154,7 +154,7 @@
   },
   {
     "name": "kompass",
-    "description": "Ett kompass visar var norr (och söder, öster, väster) befinner sig. En orienterare använder kompassen för att hålla riktning mot nästa <a href=\"/#kontroll\">kontroll</a> eller för att lägga upp kartan — vrida den så att den stämmer med terrängen runt om.",
+    "description": "Ett kompass visar var norr (och söder, öster, väster) befinner sig. En orienterare använder kompassen för att hålla riktning mot nästa <a href=\"/sv/#kontroll\">kontroll</a> eller för att lägga upp kartan — vrida den så att den stämmer med terrängen runt om.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -162,7 +162,7 @@
   },
   {
     "name": "kontroll",
-    "description": "En orienteringskontroll (även kallad flagga eller post) består av en orange-vit kontrollflagga med en tillhörande stämplingsenhet som registrerar löparens besök. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "description": "En orienteringskontroll (även kallad flagga eller post) består av en orange-vit kontrollflagga med en tillhörande stämplingsenhet som registrerar löparens besök. <i>Se <a href=\"/sv/#tidtagning\">tidtagning</a></i>.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -173,7 +173,7 @@
   },
   {
     "name": "tumkompass",
-    "description": "Ett tumkompass fästs på tummen och gör att man kan hålla karta och kompass som en enhet — den vanligaste kompasstypen bland orienterare. Traditionella plattakompassar förekommer också men är mer sällsynta i tävling. <i>Se <a href=\"/#kompass\">kompass</a></i>.",
+    "description": "Ett tumkompass fästs på tummen och gör att man kan hålla karta och kompass som en enhet — den vanligaste kompasstypen bland orienterare. Traditionella plattakompassar förekommer också men är mer sällsynta i tävling. <i>Se <a href=\"/sv/#kompass\">kompass</a></i>.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -181,7 +181,7 @@
   },
   {
     "name": "A-nivå",
-    "description": "A-nivå är den tekniskt mest krävande svårighetsgraden för en orienteringsbana. Alla orienteringstekniker behöver behärskas. <i>Se <a href=\"/#svrighetsgrad\">svårighetsgrad</a></i>.",
+    "description": "A-nivå är den tekniskt mest krävande svårighetsgraden för en orienteringsbana. Alla orienteringstekniker behöver behärskas. <i>Se <a href=\"/sv/#svrighetsgrad\">svårighetsgrad</a></i>.",
     "tags": [],
     "related": [
       "B-nivå",
@@ -193,7 +193,7 @@
   },
   {
     "name": "B-nivå",
-    "description": "B-nivå är den näst svåraste svårighetsgraden för en orienteringsbana. B-banor kräver kort finorientering in mot kontrollen och god förståelse för höjdkurvor. <i>Se <a href=\"/#svrighetsgrad\">svårighetsgrad</a></i>.",
+    "description": "B-nivå är den näst svåraste svårighetsgraden för en orienteringsbana. B-banor kräver kort finorientering in mot kontrollen och god förståelse för höjdkurvor. <i>Se <a href=\"/sv/#svrighetsgrad\">svårighetsgrad</a></i>.",
     "tags": [],
     "related": [
       "A-nivå",
@@ -205,7 +205,7 @@
   },
   {
     "name": "C-nivå",
-    "description": "C-nivå är den näst enklaste svårighetsgraden för en orienteringsbana. C-banor följer i stort sett <a href=\"/#ledlinje\">ledlinjer</a>, men löparna förväntas ibland lämna ledlinjerna. Vägvalsmöjligheter kan förekomma. <i>Se <a href=\"/#svrighetsgrad\">svårighetsgrad</a></i>.",
+    "description": "C-nivå är den näst enklaste svårighetsgraden för en orienteringsbana. C-banor följer i stort sett <a href=\"/sv/#ledlinje\">ledlinjer</a>, men löparna förväntas ibland lämna ledlinjerna. Vägvalsmöjligheter kan förekomma. <i>Se <a href=\"/sv/#svrighetsgrad\">svårighetsgrad</a></i>.",
     "tags": [],
     "related": [
       "A-nivå",
@@ -217,7 +217,7 @@
   },
   {
     "name": "N-nivå",
-    "description": "N-nivå är den enklaste svårighetsgraden för en orienteringsbana, utformad för nybörjare. N-banor följer sammanhängande <a href=\"/#ledlinje\">ledlinjer</a> som vägar, stigar, bäckar och stängsel, och alla kontroller kan ses från ledlinjen. <i>Se <a href=\"/#svrighetsgrad\">svårighetsgrad</a></i>.",
+    "description": "N-nivå är den enklaste svårighetsgraden för en orienteringsbana, utformad för nybörjare. N-banor följer sammanhängande <a href=\"/sv/#ledlinje\">ledlinjer</a> som vägar, stigar, bäckar och stängsel, och alla kontroller kan ses från ledlinjen. <i>Se <a href=\"/sv/#svrighetsgrad\">svårighetsgrad</a></i>.",
     "tags": [],
     "related": [
       "A-nivå",
@@ -229,7 +229,7 @@
   },
   {
     "name": "svårighetsgrad",
-    "description": "En orienteringsbana indelas i fyra svårighetsgrader: <a href=\"/#a-niv\">A</a>, <a href=\"/#b-niv\">B</a>, <a href=\"/#c-niv\">C</a> och <a href=\"/#n-niv\">N</a>, där A är svårast och N är nybörjarbana. Det skandinaviska graderingssystemet används i Sverige, Norge och Finland.",
+    "description": "En orienteringsbana indelas i fyra svårighetsgrader: <a href=\"/sv/#a-niv\">A</a>, <a href=\"/sv/#b-niv\">B</a>, <a href=\"/sv/#c-niv\">C</a> och <a href=\"/sv/#n-niv\">N</a>, där A är svårast och N är nybörjarbana. Det skandinaviska graderingssystemet används i Sverige, Norge och Finland.",
     "tags": [],
     "related": [
       "A-nivå",
@@ -242,7 +242,7 @@
   },
   {
     "name": "hänga",
-    "description": "Att hänga innebär att följa en annan orienterare och navigera med hjälp av dennas beslut snarare än sin egen kartläsning. Detta betraktas som dålig sportsmannaanda inom orientering. Kurskonstruktörer använder <a href=\"/#gaffling\">gaffling</a> för att motverka detta.",
+    "description": "Att hänga innebär att följa en annan orienterare och navigera med hjälp av dennas beslut snarare än sin egen kartläsning. Detta betraktas som dålig sportsmannaanda inom orientering. Kurskonstruktörer använder <a href=\"/sv/#gaffling\">gaffling</a> för att motverka detta.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -272,7 +272,7 @@
   },
   {
     "name": "O",
-    "description": "Inom orientering är man förtjust i bokstaven O och använder den så ofta som möjligt: o-skor (<a href=\"/#orienteringsskor\">orienteringsskor</a>), o-träning (orienteringsträning), o-kläder, o-sport och o-hälsning. Det är en förkortning för orientering som används flitigt i svensk orienteringskultur.",
+    "description": "Inom orientering är man förtjust i bokstaven O och använder den så ofta som möjligt: o-skor (<a href=\"/sv/#orienteringsskor\">orienteringsskor</a>), o-träning (orienteringsträning), o-kläder, o-sport och o-hälsning. Det är en förkortning för orientering som används flitigt i svensk orienteringskultur.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -361,7 +361,7 @@
   },
   {
     "name": "bryta",
-    "description": "Om du skadar dig eller kör fast så att du inte hittar nästa kontroll är alternativet att bryta. Det innebär att avbryta loppet och ta den snabbaste säkra vägen tillbaka till <a href=\"/#samlingsplats\">samlingsplatsen</a>. Det är viktigt att anmäla sig vid mål eller nedladdningsstation även när du bryter, så att funktionärerna vet att du är i säkerhet och inte behöver starta en sökinsats.",
+    "description": "Om du skadar dig eller kör fast så att du inte hittar nästa kontroll är alternativet att bryta. Det innebär att avbryta loppet och ta den snabbaste säkra vägen tillbaka till <a href=\"/sv/#samlingsplats\">samlingsplatsen</a>. Det är viktigt att anmäla sig vid mål eller nedladdningsstation även när du bryter, så att funktionärerna vet att du är i säkerhet och inte behöver starta en sökinsats.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -398,7 +398,7 @@
   },
   {
     "name": "ekvidistans",
-    "description": "Ekvidistansen är höjdskillnaden mellan två angränsande höjdkurvor (de bruna linjerna på orienteringskartan). En mindre ekvidistans möjliggör mer detaljerad höjdvisning. På de flesta orienteringskartor är ekvidistansen 5 meter. Se <a href=\"/#rknekurva\">räknekurva</a>.",
+    "description": "Ekvidistansen är höjdskillnaden mellan två angränsande höjdkurvor (de bruna linjerna på orienteringskartan). En mindre ekvidistans möjliggör mer detaljerad höjdvisning. På de flesta orienteringskartor är ekvidistansen 5 meter. Se <a href=\"/sv/#rknekurva\">räknekurva</a>.",
     "tags": [],
     "related": [],
     "aliases": [],
@@ -406,7 +406,7 @@
   },
   {
     "name": "räknekurva",
-    "description": "Var femte höjdkurva på kartan är lite tjockare — det är en räknekurva (även kallad indexkurva). Räknekurvor gör det enkelt att snabbt räkna ut större höjdskillnader. Med en <a href=\"/#ekvidistans\">ekvidistans</a> på 5 meter representerar varje räknekurva 25 meter i höjd. Tre räknekurvor innebär 75 meters höjdskillnad.",
+    "description": "Var femte höjdkurva på kartan är lite tjockare — det är en räknekurva (även kallad indexkurva). Räknekurvor gör det enkelt att snabbt räkna ut större höjdskillnader. Med en <a href=\"/sv/#ekvidistans\">ekvidistans</a> på 5 meter representerar varje räknekurva 25 meter i höjd. Tre räknekurvor innebär 75 meters höjdskillnad.",
     "tags": [],
     "related": [],
     "aliases": [
@@ -478,7 +478,7 @@
   },
   {
     "name": "cirkeln",
-    "description": "Cirkeln är den ring som markerar kontrollens exakta position på orienteringskartan. Cirkeln är centrerad på det exakta terrängobjektet som ska besökas. <i>Se även <a href=\"/#kontrollbeskrivning\">kontrollbeskrivning</a></i>.",
+    "description": "Cirkeln är den ring som markerar kontrollens exakta position på orienteringskartan. Cirkeln är centrerad på det exakta terrängobjektet som ska besökas. <i>Se även <a href=\"/sv/#kontrollbeskrivning\">kontrollbeskrivning</a></i>.",
     "tags": [],
     "related": [
       "karta",
@@ -502,7 +502,7 @@
   },
   {
     "name": "klippare",
-    "description": "En klippare är det traditionella manuella stämplingsverktyget i orientering, som användes innan elektronisk tidtagning. Den lämnar ett unikt mönster av hål i stämpelkortet när den trycks fast, vilket bevisar att löparen besökte kontrollen. Klippare syns sällan i moderna tävlingar. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "description": "En klippare är det traditionella manuella stämplingsverktyget i orientering, som användes innan elektronisk tidtagning. Den lämnar ett unikt mönster av hål i stämpelkortet när den trycks fast, vilket bevisar att löparen besökte kontrollen. Klippare syns sällan i moderna tävlingar. <i>Se <a href=\"/sv/#tidtagning\">tidtagning</a></i>.",
     "tags": [
       "tidtagning"
     ],
@@ -515,7 +515,7 @@
   },
   {
     "name": "Sportiduino",
-    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> är ett system med öppen källkod för elektronisk tidtagning i orientering och ett prisvärt alternativ till <a href=\"/#sportident\">SPORTIdent</a> och <a href=\"/#emit\">EMIT</a>. Det är baserat på Arduino-plattformen och kräver inga licenser, men ett visst mått av teknisk kompetens för att bygga kontroller och bricklösare. Ett annat alternativ med öppen källkod är <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a>.",
+    "description": "<a href=\"https://github.com/sportiduino/sportiduino\">Sportiduino</a> är ett system med öppen källkod för elektronisk tidtagning i orientering och ett prisvärt alternativ till <a href=\"/sv/#sportident\">SPORTIdent</a> och <a href=\"/sv/#emit\">EMIT</a>. Det är baserat på Arduino-plattformen och kräver inga licenser, men ett visst mått av teknisk kompetens för att bygga kontroller och bricklösare. Ett annat alternativ med öppen källkod är <a href=\"https://www.bostek.it/OribosTS.aspx\">OribosTS</a>.",
     "tags": [
       "tidtagning"
     ],
@@ -529,7 +529,7 @@
   },
   {
     "name": "SIAC",
-    "description": "SIAC (SPORTIdent Air+ Card) är SPORTIdents kontaktlösa bricka. Till skillnad från en vanlig SI-bricka behöver man inte trycka ner brickan i stämplingslådan – den registrerar automatiskt när den hålls nära kontrollenheten och piper och blinkar för att bekräfta giltig stämpling. SIAC kräver kontroller utrustade med Air+-enheter. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "description": "SIAC (SPORTIdent Air+ Card) är SPORTIdents kontaktlösa bricka. Till skillnad från en vanlig SI-bricka behöver man inte trycka ner brickan i stämplingslådan – den registrerar automatiskt när den hålls nära kontrollenheten och piper och blinkar för att bekräfta giltig stämpling. SIAC kräver kontroller utrustade med Air+-enheter. <i>Se <a href=\"/sv/#tidtagning\">tidtagning</a></i>.",
     "tags": [
       "tidtagning"
     ],
@@ -546,7 +546,7 @@
   },
   {
     "name": "emiTag",
-    "description": "emiTag är EMITs kontaktlösa bricka – motsvarigheten till <a href=\"/#siac\">SIAC</a> för SPORTIdent. Den registrerar automatiskt när den förs nära kontrollenheten utan att behöva tryckas in. Används på tävlingar med EMIT-systemet. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "description": "emiTag är EMITs kontaktlösa bricka – motsvarigheten till <a href=\"/sv/#siac\">SIAC</a> för SPORTIdent. Den registrerar automatiskt när den förs nära kontrollenheten utan att behöva tryckas in. Används på tävlingar med EMIT-systemet. <i>Se <a href=\"/sv/#tidtagning\">tidtagning</a></i>.",
     "tags": [
       "tidtagning"
     ],
@@ -561,7 +561,7 @@
   },
   {
     "name": "Huichang",
-    "description": "Huichang är ett kinesiskt elektroniskt tidtagningssystem för orientering, tillverkat av Beijing Huichang Sports Technology. Det är det dominerande tidtagningssystemet i kinesisk orientering och används brett i Asien. Systemet fungerar enligt samma princip som <a href=\"/#sportident\">SPORTIdent</a> och <a href=\"/#emit\">EMIT</a>. <i>Se <a href=\"/#tidtagning\">tidtagning</a></i>.",
+    "description": "Huichang är ett kinesiskt elektroniskt tidtagningssystem för orientering, tillverkat av Beijing Huichang Sports Technology. Det är det dominerande tidtagningssystemet i kinesisk orientering och används brett i Asien. Systemet fungerar enligt samma princip som <a href=\"/sv/#sportident\">SPORTIdent</a> och <a href=\"/sv/#emit\">EMIT</a>. <i>Se <a href=\"/sv/#tidtagning\">tidtagning</a></i>.",
     "tags": [
       "tidtagning"
     ],


### PR DESCRIPTION
Adds Finnish translation of the orienteering glossary (53 entries), closing the last remaining language in issue #97.

Key Finnish-specific adaptations:
- **Rastilippu/Irma** replaces Eventor (Finnish event management system)
- **EMIT** highlighted as dominant timing system in Finland
- **N/M** class prefixes (naiset/miehet) instead of Scandinavian D/H
- **Jukola** described from a Finnish perspective, including Venlojen viesti
- **kiintorastit** for permanent courses
- **kuntosarjat** for open entry classes
- **tarkkuussuunnistus** for trail orienteering
- **viesti** for relay (not kavle/budkavle)
- **vaikeusaste** with A/B/C/N system (used in Finland, Norway, Sweden)

Closes #97