### PR TITLE
fix: update rankingløp link

### DIFF
--- a/resources/orienteering_dictionary.json
+++ b/resources/orienteering_dictionary.json
@@ -110,7 +110,7 @@
   },
   {
     "name": "Rankingløp",
-    "description": "Rankingløp er uformelle treningsløp som arrangeres ukentlig av OSI Orientering og IL GeoForm. For hvert løp man løper samler man poeng til en totalranking, derav navnet Rankingløp. Se mer på vår side om <a href=\"https://ilgeoform.no/rankinglop/\">rankingløp</a>.",
+    "description": "Rankingløp er uformelle treningsløp som arrangeres ukentlig av OSI Orientering og IL GeoForm. For hvert løp man løper samler man poeng til en totalranking, derav navnet Rankingløp. Se mer på vår side om <a href=\"https://ilgeoform.no/\">rankingløp</a>.",
     "tags": [],
     "related": [],
     "aliases": [],

--- a/resources/orienteering_dictionary_da.json
+++ b/resources/orienteering_dictionary_da.json
@@ -117,7 +117,7 @@
   },
   {
     "name": "rankingløb",
-    "description": "Rankingløp er et uformelt træningsløb arrangeret ugentligt af OSI Orientering og IL GeoForm i Oslo. Point samles op gennem sæsonen til en samlet ranking — deraf navnet. Se <a href=\"https://ilgeoform.no/rankinglop/\">Rankingløp-siden</a> for mere information.",
+    "description": "Rankingløp er et uformelt træningsløb arrangeret ugentligt af OSI Orientering og IL GeoForm i Oslo. Point samles op gennem sæsonen til en samlet ranking — deraf navnet. Se <a href=\"https://ilgeoform.no/\">Rankingløp-siden</a> for mere information.",
     "tags": [],
     "related": [],
     "aliases": [],

--- a/resources/orienteering_dictionary_en.json
+++ b/resources/orienteering_dictionary_en.json
@@ -121,7 +121,7 @@
   },
   {
     "name": "Rankingløp",
-    "description": "Rankingløp is an informal training race series organised weekly by OSI Orientering and IL GeoForm in Oslo. Points are accumulated over the season to build a total ranking — hence the name. See the <a href=\"https://ilgeoform.no/rankinglop/\">Rankingløp page</a> for more information.",
+    "description": "Rankingløp is an informal training race series organised weekly by OSI Orientering and IL GeoForm in Oslo. Points are accumulated over the season to build a total ranking — hence the name. See the <a href=\"https://ilgeoform.no/\">Rankingløp page</a> for more information.",
     "tags": [],
     "related": [],
     "aliases": [],

--- a/resources/orienteering_dictionary_fi.json
+++ b/resources/orienteering_dictionary_fi.json
@@ -121,7 +121,7 @@
   },
   {
     "name": "Rankingløp",
-    "description": "Rankingløp on viikoittain järjestettävä epävirallinen harjoituskilpailusarja, jonka OSI Orientering ja IL GeoForm organisoivat Oslossa. Pisteitä kertyy kauden aikana kokonaissijoitukseen — siitä nimi. Lisätietoja <a href=\"https://ilgeoform.no/rankinglop/\">Rankingløp-sivulla</a>.",
+    "description": "Rankingløp on viikoittain järjestettävä epävirallinen harjoituskilpailusarja, jonka OSI Orientering ja IL GeoForm organisoivat Oslossa. Pisteitä kertyy kauden aikana kokonaissijoitukseen — siitä nimi. Lisätietoja <a href=\"https://ilgeoform.no/\">Rankingløp-sivulla</a>.",
     "tags": [],
     "related": [],
     "aliases": [],

--- a/resources/orienteering_dictionary_sv.json
+++ b/resources/orienteering_dictionary_sv.json
@@ -120,7 +120,7 @@
   },
   {
     "name": "Rankingløp",
-    "description": "Rankingløp är ett informellt träningslopp som arrangeras veckovis av OSI Orientering och IL GeoForm i Oslo. Poäng samlas under säsongen till en totalrankning — därav namnet. Se mer på <a href=\"https://ilgeoform.no/rankinglop/\">Rankingløp-sidan</a>.",
+    "description": "Rankingløp är ett informellt träningslopp som arrangeras veckovis av OSI Orientering och IL GeoForm i Oslo. Poäng samlas under säsongen till en totalrankning — därav namnet. Se mer på <a href=\"https://ilgeoform.no/\">Rankingløp-sidan</a>.",
     "tags": [],
     "related": [],
     "aliases": [],


### PR DESCRIPTION
Fixes #114

Update the link to rankingløp from `https://ilgeoform.no/rankinglop/` to `https://ilgeoform.no/` in all dictionary files.